### PR TITLE
Rename in one commit

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ function App() {
             {loggedIn && <>
                 <Route path="edit/:branch/*" element={<EditorScreen />} />
                 <Route path="edit/:branch" element={<EditorScreen />} />
-                <Route path="*" element={<RedirectTo path="edit/master" />} />
+                <Route path="*" element={<RedirectTo path={`edit/${defaultGithubContext.branch}`} />} />
             </>}
         </Routes>
     </HistoryRouter>;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -55,7 +55,7 @@ function App() {
             {loggedIn && <>
                 <Route path="edit/:branch/*" element={<EditorScreen />} />
                 <Route path="edit/:branch" element={<EditorScreen />} />
-                <Route path="*" element={<RedirectTo path={`edit/${defaultGithubContext.branch}`} />} />
+                <Route path="*" element={<RedirectTo path={`edit/${encodeURIComponent(defaultGithubContext.branch)}`} />} />
             </>}
         </Routes>
     </HistoryRouter>;

--- a/src/components/popups/PopupMenu.tsx
+++ b/src/components/popups/PopupMenu.tsx
@@ -118,7 +118,6 @@ export function PopupMenu({menuRef}: { menuRef: MutableRefObject<PopupMenuRef | 
                 type: "rename",
                 path: item.path,
                 name: item.name,
-                sha: item.sha,
             })} text="Rename..." />}
             {item?.type === "file" && isCurrentFile && <MenuItem onClick={() => appContext.dispatch({
                 type: "saveAs",

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -10,6 +10,7 @@ import { dirname } from "../utils/strings";
 import { Config, getConfig } from "./config";
 
 export const GITHUB_TOKEN_COOKIE = "github-token";
+const GITHUB_API_URL = "https://api.github.com/";
 
 export function githubReplaceWithConfig(path: string) {
     const config = getConfig();
@@ -18,8 +19,8 @@ export function githubReplaceWithConfig(path: string) {
     });
 }
 
-export const fetcher = async (path: string, options?: Omit<RequestInit, "body"> & {body: Record<string, unknown>}) => {
-    const fullPath = "https://api.github.com/" + githubReplaceWithConfig(path);
+export const fetcher = async (path: string, options?: Omit<RequestInit, "body"> & {body?: Record<string, unknown>}) => {
+    const fullPath = GITHUB_API_URL + githubReplaceWithConfig(path);
 
     const result = await fetch(fullPath, {
         ...options,
@@ -57,6 +58,12 @@ export const useGithubContents = (context: ContextType<typeof AppContext>, path:
     return useSWR(typeof path === "string" ? contentsPath(path, context.github.branch) : null);
 };
 
+export const defaultGithubContext = {
+    branch: "master",
+    user: {login: "invalid-user"} as User,
+    cache: undefined as unknown as Cache,
+};
+
 export async function processCode(code: string | null) {
     if (code) {
         // Exchange the code for a token, put that in a cookie
@@ -68,7 +75,7 @@ export async function processCode(code: string | null) {
 
         const dest = new URL(window.location.href);
         if (dest.pathname === "" || dest.pathname === "/") {
-            dest.pathname = "edit/master";
+            dest.pathname = `edit/${defaultGithubContext.branch}`;
         }
         // Either way, take code out of query string
         dest.searchParams.delete("code");
@@ -79,12 +86,6 @@ export async function processCode(code: string | null) {
 export interface User {
     login: string;
 }
-
-export const defaultGithubContext = {
-    branch: "master",
-    user: {login: "invalid-user"} as User,
-    cache: undefined as unknown as Cache,
-};
 
 export async function githubCreate(context: ContextType<typeof AppContext>, basePath: string, name: string, initialContent: string) {
     const path = `${basePath}/${name}`;
@@ -150,6 +151,113 @@ export async function githubDelete(context: ContextType<typeof AppContext>, path
             return newDir;
         }
         return current;
+    }, {revalidate: false}); // github asks for aggressive disk caching, which we need to override.
+}
+
+// Adapted from this blog post: https://medium.com/@obodley/renaming-a-file-using-the-git-api-fed1e6f04188
+export async function githubRename(context: ContextType<typeof AppContext>, path: string, name: string) {
+    let isPublished;
+    try {
+        isPublished = context.editor.isAlreadyPublished();
+    } catch {
+        isPublished = false;
+    }
+    const pathSegments = path.split("/");
+    const basePath = dirname(path);
+    const oldName = pathSegments.at(-1);
+
+    // Ensure that another file with the same name doesn't already exist, because the renaming process will overwrite
+    // existing files otherwise
+    const current: Entry[] = context.github.cache.get(contentsPath(basePath, context.github.branch));
+    const index = current.findIndex((entry) => {
+        return name === entry.name;
+    });
+    if (index !== -1) throw Error(`A file with the name ${name} already exists in the same directory. Cannot rename!`);
+
+    // It is now safe to rename...
+
+    // Get the current branch commit sha - GitHub asks the browser to cache these branch requests for 60 seconds, which will
+    // cause things to break if we try to rename twice in a 60 second period. To bypass this, we add a timestamp as a
+    // query param to the URL, allowing us to get the freshest branch commit sha each time.
+    const branch = await fetcher(`repos/$OWNER/$REPO/branches/${context.github.branch}?cache_t=${new Date().getTime()}`, {
+        method: "GET"
+    });
+    const baseSha = branch.commit.sha;
+    // Get the entire git tree at this point
+    let subtree = await fetcher(`repos/$OWNER/$REPO/git/trees/${baseSha}`, {
+        method: "GET"
+    });
+    // Find the tree node corresponding to the file we want to rename
+    for (const segment of pathSegments.slice(0, -1)) {
+        const nextTree = subtree.tree.find((t: any) => t.path === segment);
+        if (nextTree) {
+            subtree = await fetcher(nextTree.url.replace(GITHUB_API_URL, ""), {
+                method: "GET"
+            });
+        } else {
+            console.error("Cannot find file in git tree - cannot rename!");
+            return;
+        }
+    }
+
+    const blob = subtree?.tree?.find((b: any) => b.path === oldName);
+    if (!blob) throw Error("A file with that name does not exist on the current branch.");
+
+    // Send the modified tree to github, with the updated path
+    const newTree = await fetcher(`repos/$OWNER/$REPO/git/trees?recursive=1`,{
+        method: "POST",
+        body: {
+            "base_tree": baseSha,
+            "tree": [
+                {
+                    "path": `${basePath}/${name}`,
+                    "mode": blob.mode,
+                    "type": blob.type,
+                    "sha": blob.sha
+                },
+                {
+                    "path": `${basePath}/${blob.path}`,
+                    "mode": blob.mode,
+                    "type": blob.type,
+                    "sha": null
+                }
+            ]
+        }
+    });
+
+    // Commit the new tree with a message
+    const commit = await fetcher(`repos/$OWNER/$REPO/git/commits`, {
+        method: "POST",
+        body: {
+            "message": `${isPublished ? "* " : ""}Rename ${blob.path} to ${name}`,
+            "tree": newTree.sha,
+            "parents": [baseSha]
+        }
+    });
+    // Point the current branch at the new commit
+    await fetcher(`repos/$OWNER/$REPO/git/refs/heads/${context.github.branch}`, {
+        method: "PATCH",
+        body: {
+            "sha": commit.sha
+        }
+    });
+
+    // This essentially merges the create and delete mutations
+    await mutate(contentsPath(basePath, context.github.branch), (current: Entry[]) => {
+        const newDir = [...current];
+        const oldPosition = newDir.findIndex((entry) => {
+            return oldName === entry.name;
+        });
+        const oldFileData = {...current[oldPosition]};
+        if (oldPosition !== -1) {
+            newDir.splice(oldPosition, 1);
+        }
+        let newPosition = newDir.findIndex((entry) => {
+            return name < entry.name;
+        });
+        if (newPosition === -1) newPosition = newDir.length;
+        newDir.splice(newPosition, 0, {...oldFileData, name: name, path: `${basePath}/${name}`});
+        return newDir;
     }, {revalidate: false}); // github asks for aggressive disk caching, which we need to override.
 }
 


### PR DESCRIPTION
This can be tested by changing `defaultGithubContext.branch` to `"rename-in-one-commit"` (a test branch on `isaac-content-2`, should be deleted once this is sorted).