### PR TITLE
Add editor support for IsaacCardDeck

### DIFF
--- a/src/components/semantic/Inserter.tsx
+++ b/src/components/semantic/Inserter.tsx
@@ -36,6 +36,7 @@ const blockTypes = {
     "accordion": {type: "content", layout: "accordion", encoding: "markdown", children: []},
     "side-by-side layout": {type: "content", layout: "horizontal", encoding: "markdown", children: []},
     "callout": {type: "content", layout: "callout", encoding: "markdown", value: ""},
+    "card deck": {type: "isaacCardDeck", encoding: "markdown", value: ""},
 };
 
 export function Inserter({insert, forceOpen, position}: InserterProps) {

--- a/src/components/semantic/presenters/CardPresenter.tsx
+++ b/src/components/semantic/presenters/CardPresenter.tsx
@@ -5,22 +5,27 @@ import { IsaacCard, IsaacCardDeck } from "../../../isaac-data-types";
 import { PresenterProps } from "../registry";
 import { CheckboxDocProp } from "../props/CheckboxDocProp";
 import { SemanticDocProp } from "../props/SemanticDocProp";
-import { EditableDocPropFor } from "../props/EditableDocProp";
+import { EditableDocPropFor, EditableSubtitleProp, EditableTitleProp } from "../props/EditableDocProp";
 import { ListPresenterProp } from "../props/listProps";
 
 const EditableURL = EditableDocPropFor<IsaacCard>("clickUrl");
 
 export function CardPresenter(props: PresenterProps<IsaacCard>) {
     return <>
-        <EditableURL {...props} label="URL" block />
+        <h2><EditableTitleProp {...props} placeHolder="Card title" /></h2>
+        <EditableSubtitleProp {...props} placeHolder="Card text" />
+        <EditableURL {...props} label="Link URL" block />
         <div>
-            <CheckboxDocProp {...props} prop="verticalContent" label="Vertical" />
-            <CheckboxDocProp {...props} prop="disabled" label="Disabled" />
+            <CheckboxDocProp {...props} prop="verticalContent" label="Vertical layout" />
+            <CheckboxDocProp {...props} prop="disabled" label="Link disabled" />
         </div>
         <SemanticDocProp {...props} prop="image" />
     </>;
 }
 
 export function CardDeckPresenter(props: PresenterProps<IsaacCardDeck>) {
-    return <ListPresenterProp {...props} prop="cards" childTypeOverride="isaacCard" />;
+    return <>
+        <h1><EditableTitleProp {...props} placeHolder="Card deck title" /></h1>
+        <ListPresenterProp {...props} prop="cards" childTypeOverride="isaacCard" />
+    </>;
 }

--- a/src/services/commands.ts
+++ b/src/services/commands.ts
@@ -88,15 +88,7 @@ async function doNew(context: ContextType<typeof AppContext>, action: ActionFor<
                         {
                             caption: "News pod",
                             value: "isaacPod"
-                        },
-                        {
-                            caption: "Card",
-                            value: "isaacCard"
-                        },
-                        {
-                            caption: "Card deck",
-                            value: "isaacCardDeck"
-                        },
+                        }
                     ],
                     callback: async (option) => {
                         if (option === null) {

--- a/src/services/config.ts
+++ b/src/services/config.ts
@@ -5,6 +5,7 @@ export interface Config {
     authCode: string;
     OWNER: string;
     REPO: string;
+    APP_REPO: string;
     previewServer: string;
 }
 
@@ -14,12 +15,14 @@ const configs: { [host: string]: Config } = {
         authCode: "/vFaDdbb7id6+cPgsIKTdvwk4lOLBkBpBsXDdBvZsnU0U/PBLxgzxDzmUfE/0OIWWvlxh7SigvVv1JzBffbEc2364W8GPmQt9QeuVW1juAHdvdT7kRrHv8LjEuxJP9ie9+BP3tXNWpVxdg7S3sbZA5ShBFOYxdr3izjn9L+cmzDT9YVKB+Grv8hvLcEFOy7KHeixa29HPY2pqtk6XHFqiwlDP+02AWmY",
         OWNER: "isaacphysics",
         REPO: "rutherford-content",
+        APP_REPO: "isaac-react-app",
         previewServer: "http://localhost:3002",
     }, {
         clientId: "f62f2bd4954bf930bc3f",
         authCode: "/vFaDdbb7id6+cPgsIKTdvwk4lOLBkBpBsXDdBvZsnU0U/PBLxgzxDzmUfE/0OIWWvlxh7SigvVv1JzBffbEc2364W8GPmQt9QeuVW1juAHdvdT7kRrHv8LjEuxJP9ie9+BP3tXNWpVxdg7S3sbZA5ShBFOYxdr3izjn9L+cmzDT9YVKB+Grv8hvLcEFOy7KHeixa29HPY2pqtk6XHFqiwlDP+02AWmY",
         OWNER: "isaacphysics",
         REPO: "isaac-content-2",
+        APP_REPO: "isaac-react-app",
         previewServer: "http://localhost:3001",
     }),
     "editor.isaacphysics.org": {
@@ -27,6 +30,7 @@ const configs: { [host: string]: Config } = {
         authCode : "j4GsAFDYXaxqwN146vTeQ4vbV7ucQtGC8B4AI7EVQPIUTQG/nz9Yfgm1o3d0FLrDlgGyig2YyxA8IMS1wVF+mZ7rCMzOZUXGIn48gDxFGzsWZKhK36kwra5PE3C6mCeRQjXx6cCyl9VRH1VR+RsjIXM6vIdD0g1JqcupsKDNmojZAcuMkPreJfl2h+bbss1DGw3CdvNLF8lwd895OTNwZfGjQxcmywIS3VIC7o6JIq3fcw==",
         OWNER: "isaacphysics",
         REPO: "rutherford-content",
+        APP_REPO: "isaac-react-app",
         previewServer: "https://editor-preview.isaacphysics.org",
     },
     "editor.isaaccomputerscience.org": {
@@ -34,6 +38,7 @@ const configs: { [host: string]: Config } = {
         authCode : "WD4uGrm2iTFxmvwHjybnCSzIpgFk3r//7twVti62RpnQWyFteaKK11q6wLBQX6bb/yy9NY9t0m79MxokXUVZpRNzczPvBAkW6WGfmdCUa5tNs3UMswWmpITiv/TiGHJKxDRZ9m2KYgly3jqLzEU1EY7KznCCa16x7MLzdcQzyYKYS49RB3V/+B7IsuyDPQLRVffRTe/2MkrZmx98kj9x14eMgteIRQ7aYhi1pDsYE1dVGOMyojgoPsf6",
         OWNER: "isaacphysics",
         REPO: "isaac-content-2",
+        APP_REPO: "isaac-react-app",
         previewServer: "https://editor-preview.isaaccomputerscience.org",
     },
 };

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -12,6 +12,11 @@ import {Config, getConfig} from "./config";
 export const GITHUB_TOKEN_COOKIE = "github-token";
 const GITHUB_API_URL = "https://api.github.com/";
 
+const GITHUB_BASE_REPO_PATHS: {[key: string] : string} = {
+    content: "repos/$OWNER/$REPO/contents/",
+    app: "repos/$OWNER/$APP_REPO/contents/public"
+}
+
 export function githubReplaceWithConfig(path: string) {
     const config = getConfig();
     return path.replace(/\$([A-Z_]+)/g, (_, match) => {
@@ -56,16 +61,16 @@ export const fetcher = async (path: string, options?: Omit<RequestInit, "body"> 
     }
 };
 
-function contentsPath(path: string, branch?: string) {
-    let fullPath = `repos/$OWNER/$REPO/contents/${path}`;
+function contentsPath(path: string, branch?: string, repo: string = "content") {
+    let fullPath = `${GITHUB_BASE_REPO_PATHS[repo]}${path}`;
     if (branch) {
         fullPath += `?ref=${encodeURIComponent(branch)}`;
     }
     return fullPath;
 }
 
-export const useGithubContents = (context: ContextType<typeof AppContext>, path: string|false|null|undefined) => {
-    return useSWR(typeof path === "string" ? contentsPath(path, context.github.branch) : null);
+export const useGithubContents = (context: ContextType<typeof AppContext>, path: string|false|null|undefined, repo?: string) => {
+    return useSWR(typeof path === "string" ? contentsPath(path, context.github.branch, repo) : null);
 };
 
 export const defaultGithubContext = {


### PR DESCRIPTION
Adds editable fields for title and subtitle to the card content block. Also removes the IsaacCard and IsaacCardDeck options from the "create page" modal and adds IsaacCardDeck to the "new content block" modal.

Also adds the ability to preview assets packaged with the frontend, which are still used in some places.