### PR TITLE
Overflowing entries in item choice dropdown menu

### DIFF
--- a/src/components/semantic/ExpandableText.tsx
+++ b/src/components/semantic/ExpandableText.tsx
@@ -1,0 +1,24 @@
+import React, {MouseEventHandler, useState} from "react";
+import {Button} from "reactstrap";
+import styles from "./styles/question.module.css";
+
+const MAX_CHARS_BEFORE_SHORTEN = 75;
+export function ExpandableText({text}: {text?: string}) {
+    const needsToBeShortened = text && (text.length > MAX_CHARS_BEFORE_SHORTEN);
+    const [shortened, setShortened] = useState<boolean>(true);
+    const toggle: MouseEventHandler<HTMLButtonElement> = (e) => {
+        setShortened(s => !s);
+        e.stopPropagation();
+    };
+    if (text && needsToBeShortened) {
+        const shortenedText = text.slice(0, MAX_CHARS_BEFORE_SHORTEN);
+        return <>
+            {shortened ? shortenedText : text}<span>{shortened && "..."}</span>
+            <br/>
+            <div className={"w-100 text-center"}>
+                <Button size={"sm"} color="link" className={styles.expandTextButton} onClick={toggle}><small>(Show {shortened ? "more" : "less"})</small></Button>
+            </div>
+        </>;
+    }
+    return <>{text ?? ""}</>;
+}

--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -137,7 +137,7 @@ export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
         return <div className={styles.parsonsItem}
                     style={{borderLeftWidth: `calc(1px + ${(doc.indentation ?? 0) * 1.5}em)`}}>
             {dropdown}
-            <span>
+            <span className={styles.parsonsIndentPresenter}>
                 <MetaItemPresenter {...props} prop="indentation" name="Indent"
                                    options={indentationOptions} />
             </span>

--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -1,4 +1,4 @@
-import React, {createContext, useContext, useState} from "react";
+import React, {createContext, MouseEventHandler, useContext, useState} from "react";
 import {Button, Col, Dropdown, DropdownItem, DropdownMenu, DropdownToggle, Row} from "reactstrap";
 
 import {
@@ -21,6 +21,7 @@ import {MetaItemPresenter, MetaOptions} from "../Metadata";
 
 import styles from "../styles/question.module.css";
 import {Box} from "../SemanticItem";
+import {ExpandableText} from "../ExpandableText";
 
 interface ItemsContextType {
     items: ParsonsItem[] | undefined;
@@ -86,8 +87,8 @@ function ItemRow({item}: {item: Item}) {
         <Col xs={3}>
             {item.id}
         </Col>
-        <Col xs={9}>
-            {item.value}
+        <Col xs={9} className={styles.itemRowText}>
+            <ExpandableText text={item.value}/>
         </Col>
     </Row>
 }
@@ -112,15 +113,15 @@ export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
 
     const dropdown = <Dropdown toggle={() => setOpen(toggle => !toggle)}
                                isOpen={isOpen}>
-        <DropdownToggle outline>
+        <DropdownToggle outline className={styles.dropdownButton}>
             <ItemRow item={item} />
         </DropdownToggle>
-        <DropdownMenu>
-            <DropdownItem key={item.id} active>
+        <DropdownMenu className={styles.itemChoiceDropdown}>
+            <DropdownItem key={item.id} className={styles.dropdownItem} active>
                 <ItemRow item={item} />
             </DropdownItem>
             {remainingItems?.map((i) => {
-                return <DropdownItem key={i.id} onClick={() => {
+                return <DropdownItem key={i.id} className={styles.dropdownItem} onClick={() => {
                     update({
                         ...doc,
                         id: i.id,

--- a/src/components/semantic/styles/question.module.css
+++ b/src/components/semantic/styles/question.module.css
@@ -66,7 +66,7 @@
     margin-bottom: 0.5em;
 }
 
-.itemsChoiceRow button, .parsonsItem button {
+.itemsChoiceRow .dropdownButton, .parsonsItem .dropdownButton {
     width: 100%;
     border: none !important;
     background: none !important;
@@ -76,6 +76,31 @@
 .itemsChoiceInserter {
     margin-top: 0.5em;
     width: 100%;
+}
+
+.itemRowText {
+    white-space: normal !important;
+    overflow-wrap: break-word;
+}
+
+.dropdownItem {
+    min-width: 300px;
+}
+
+.dropdownItem[class*="active"], .dropdownItem:active {
+    border-radius: 3px;
+}
+
+/* Workaround using attribute selectors to inspect bootstrap classes */
+.dropdownItem[class*="active"] .expandTextButton, .dropdownItem:active .expandTextButton {
+    color: white !important;
+}
+
+.itemChoiceDropdown {
+    padding-top: 0;
+    padding-bottom: 0;
+    overflow-y: auto;
+    max-height: 100vh;
 }
 
 .parsonsItem {
@@ -88,12 +113,4 @@
     margin-left: calc(-1em - 1px);
     display: flex;
     padding-right: 75px; /* Room for up/down/delete buttons */
-}
-
-.parsonsItem :nth-child(1) {
-    flex: 3;
-}
-
-.parsonsItem :nth-child(2) {
-    flex-basis: 80px;
 }

--- a/src/components/semantic/styles/question.module.css
+++ b/src/components/semantic/styles/question.module.css
@@ -114,3 +114,7 @@
     display: flex;
     padding-right: 75px; /* Room for up/down/delete buttons */
 }
+
+.parsonsIndentPresenter {
+    min-width: 50px;
+}


### PR DESCRIPTION
A good example is section 7 and 8 of Matthew Rihans test page: https://editor.isaacphysics.org/edit/master/content/beta_pages/matthew/matthew_practice.json

Previously:
![image](https://user-images.githubusercontent.com/33040507/187950456-d34794e5-3a00-4226-a1d9-fad7111236f3.png)

With this change:
![image](https://user-images.githubusercontent.com/33040507/187950626-a270023b-8252-493b-a480-ca309ba3797a.png)
