### PR TITLE
Stop trying to generate figure numbers for non-static figures

### DIFF
--- a/src/components/semantic/presenters/FigurePresenter.tsx
+++ b/src/components/semantic/presenters/FigurePresenter.tsx
@@ -25,6 +25,17 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
 
     const imageRef = useRef<HTMLImageElement>(null);
     useEffect(() => {
+        function inlineBase64URLFromGithubData(data: { content: string; }) {
+            let type = "image";
+            switch (getImageFileType(doc.src)) {
+                case "png": type = "image/png"; break;
+                case "jpg": type = "image/jpeg"; break;
+            }
+
+            const b64 = data.content;
+            return "data:" + type + ";base64," +  b64;
+        }
+
         if (data && data.content) {
             let dataUrl;
             if (getImageFileType(doc.src) === "svg") {
@@ -39,7 +50,7 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
                 imageRef.current.src = dataUrl;
             }
         }
-    }, [data, doc.src, inlineBase64URLFromGithubData]);
+    }, [data, doc.src]);
 
     const fileRef = useRef<HTMLInputElement>(null);
 
@@ -52,17 +63,6 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
 
     function isAppAsset(path?: string) {
         return path && path.startsWith('/assets')
-    }
-
-    function inlineBase64URLFromGithubData(data: { content: string; }) {
-        let type = "image";
-        switch (getImageFileType(doc.src)) {
-            case "png": type = "image/png"; break;
-            case "jpg": type = "image/jpeg"; break;
-        }
-
-        const b64 = data.content;
-        return "data:" + type + ";base64," +  b64;
     }
 
     function githubURLFromGithubData(data: {download_url: string}, svgView?: string) {

--- a/src/components/semantic/presenters/FigurePresenter.tsx
+++ b/src/components/semantic/presenters/FigurePresenter.tsx
@@ -11,6 +11,8 @@ import { dirname } from "../../../utils/strings";
 import { useFixedRef } from "../../../utils/hooks";
 
 import styles from "../styles/figure.module.css";
+import {NON_STATIC_FIGURE_FLAG} from "../../../isaac/IsaacTypes";
+import {Alert} from "reactstrap";
 
 export function FigurePresenter(props: PresenterProps<Figure>) {
     const {doc, update} = props;
@@ -126,6 +128,10 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
         selectFile(fileRef.current?.files[0]);
     }
 
+    const figureNumberText = figureNumber === NON_STATIC_FIGURE_FLAG
+        ? <Alert color={"danger"}><small>Figure is in a non-static context, so cannot be given a number</small></Alert>
+        : <h6>{figureNumber ? `Figure ${figureNumber}` : "Set ID to get a figure number"}</h6>;
+
     return <>
         <div className={styles.figureWrapper}>
             <div className={styles.figureImage}>
@@ -136,7 +142,7 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
             </div>
             <div className={styles.figureCaption}>
                 {doc.type === "figure" && <>
-                    <h6>{figureNumber ? `Figure ${figureNumber}` : "Set ID to get a figure number"}</h6>
+                    {figureNumberText}
                     <ContentValueOrChildrenPresenter {...props} topLevel />
                 </>}
                 {doc.attribution && <>

--- a/src/isaac/IsaacTypes.ts
+++ b/src/isaac/IsaacTypes.ts
@@ -5,5 +5,6 @@ export interface BooleanNotation {
     MATH?: boolean;
 }
 
-export interface FigureNumbersById {[figureId: string]: number}
+export const NON_STATIC_FIGURE_FLAG = "NON_STATIC_FIGURE";
+export interface FigureNumbersById {[figureId: string]: number | typeof NON_STATIC_FIGURE_FLAG | undefined}
 export const FigureNumberingContext = createContext<FigureNumbersById>({});

--- a/src/isaac/WithFigureNumbering.tsx
+++ b/src/isaac/WithFigureNumbering.tsx
@@ -10,7 +10,6 @@ export function extractFigureId(id: string) {
 export const useFigureNumbering = (doc: Content) => {
     const figureMap = useRef<Record<string, number | typeof NON_STATIC_FIGURE_FLAG | undefined>>({});
 
-    const figuresOutOfStaticFlow = new Set<string>();
     const newMap = {} as Record<string, number | typeof NON_STATIC_FIGURE_FLAG | undefined>;
     let n = 1;
     function walk(d: Content | Question | ChoiceQuestion | undefined, outOfStaticFlow: boolean) {

--- a/src/isaac/WithFigureNumbering.tsx
+++ b/src/isaac/WithFigureNumbering.tsx
@@ -1,6 +1,6 @@
 import { useRef } from "react";
 
-import { Content, Question } from "../isaac-data-types";
+import {ChoiceQuestion, Content, Question} from "../isaac-data-types";
 
 export function extractFigureId(id: string) {
     return id.replace(/.*?([^|]*)$/g, '$1');
@@ -9,34 +9,50 @@ export function extractFigureId(id: string) {
 export const useFigureNumbering = (doc: Content) => {
     const figureMap = useRef<Record<string, number>>({});
 
+    const figuresOutOfNormalFlow = new Set<string>();
     const newMap = {} as Record<string, number>;
     let n = 1;
-    function walk(d: Content|Question|undefined) {
+    function walk(d: Content | Question | ChoiceQuestion | undefined, outOfNormalFlow: boolean) {
         if (!d) {
             // Nothing to see here. Move along.
             return;
         } else if (d.type === "figure" && d.id) {
-            const figureId = extractFigureId(d.id)
-            if (!Object.keys(newMap).includes(figureId)) {
+            const figureId = extractFigureId(d.id);
+            if (outOfNormalFlow) {
+                figuresOutOfNormalFlow.add(figureId);
+            } else if (!Object.keys(newMap).includes(figureId)) {
                 newMap[figureId] = n++;
             }
         } else {
             // Walk all the things that might possibly contain figures. Doesn't blow up if they don't exist.
             if (Array.isArray(d.children)) {
                 for (const c of d.children) {
-                    walk(c);
+                    walk(c, outOfNormalFlow);
                 }
             }
             if (typeof d === "object" && "answer" in d) {
-                walk(d.answer);
+                walk(d.answer, outOfNormalFlow);
                 for (const h of d.hints || []) {
-                    walk(h);
+                    walk(h, outOfNormalFlow);
+                }
+                // Walk figures in question choices, marking them as being out of the usual document flow
+                if ("choices" in d) {
+                    for (const c of d.choices || []) {
+                        walk(c.explanation, true);
+                    }
                 }
             }
             // If we find that some figures aren't getting numbers, add additional walks here to find them.
         }
     }
-    walk(doc);
+    walk(doc, false);
+
+    // Add all figures that exist out of the normal flow of the document (figures in choices for example)
+    for (const figureId of figuresOutOfNormalFlow.values()) {
+        if (!Object.keys(newMap).includes(figureId)) {
+            newMap[figureId] = n++;
+        }
+    }
 
     // Check maps match, or update ref if they do not.
     const oldMap = figureMap.current;

--- a/src/isaac/WithFigureNumbering.tsx
+++ b/src/isaac/WithFigureNumbering.tsx
@@ -1,4 +1,4 @@
-import { useRef } from "react";
+import {useRef} from "react";
 
 import {ChoiceQuestion, Content, Question} from "../isaac-data-types";
 import {NON_STATIC_FIGURE_FLAG} from "./IsaacTypes";
@@ -19,10 +19,8 @@ export const useFigureNumbering = (doc: Content) => {
             return;
         } else if (d.type === "figure" && d.id) {
             const figureId = extractFigureId(d.id);
-            if (outOfStaticFlow) {
-                figuresOutOfStaticFlow.add(figureId);
-            } else if (!Object.keys(newMap).includes(figureId)) {
-                newMap[figureId] = n++;
+            if (!Object.keys(newMap).includes(figureId) || newMap[figureId] === NON_STATIC_FIGURE_FLAG) {
+                newMap[figureId] = outOfStaticFlow ? NON_STATIC_FIGURE_FLAG : (n++);
             }
         } else {
             // Walk all the things that might possibly contain figures. Doesn't blow up if they don't exist.
@@ -48,11 +46,6 @@ export const useFigureNumbering = (doc: Content) => {
         }
     }
     walk(doc, false);
-
-    // Mark all figures that exist out of the static flow of the document as such (figures in choices for example)
-    for (const figureId of figuresOutOfStaticFlow.values()) {
-        newMap[figureId] = NON_STATIC_FIGURE_FLAG;
-    }
 
     // Check maps match, or update ref if they do not.
     const oldMap = figureMap.current;


### PR DESCRIPTION
IMO we shouldn't try to generate figure numbers for figures in question feedback (or anything that doesn't exist in the document on page load). 
It's too complicated to get it right and I think any halfway-decent solution will be hard to implement/hard for the content teams to use and adapt to. It's also an edge case that doesn't occur often, so it is not worth looking much into.

This PR marks figures in question feedback as 'non-static' in the editor, and a warning message is shown indicating that the figure won't be given a number and so won't be referenceable with `\ref{...}`. This at least makes it transparent to the content team what's going on and why.

Section 4 of [this page](https://editor.isaacphysics.org/edit/master/content/questions/maths/functions/general_functions/alevel/function_types_inverses.json) is useful to test whether this is working properly.