### PR TITLE
Use CodeMirror for text props formatted as "code"

### DIFF
--- a/src/components/semantic/presenters/CodeSnippetPresenter.tsx
+++ b/src/components/semantic/presenters/CodeSnippetPresenter.tsx
@@ -7,7 +7,7 @@ import { EditableDocPropFor } from "../props/EditableDocProp";
 import { PresenterProps } from "../registry";
 import { Dropdown, DropdownItem, DropdownMenu, DropdownToggle } from "reactstrap";
 
-const EditableCode = EditableDocPropFor<CodeSnippet>("code");
+const EditableCode = EditableDocPropFor<CodeSnippet>("code", {format: "code"});
 const EditableUrl = EditableDocPropFor<CodeSnippet>("url");
 
 const Languages = {
@@ -50,7 +50,7 @@ export function CodeSnippetPresenter(props: PresenterProps<CodeSnippet>) {
     return <>
         <LanguageSelector {...props} />
         <CheckboxDocProp {...props} prop="disableHighlighting" label="Disable highlighting" />
-        <EditableCode {...props} label="Code" multiLine block format="code" />
+        <EditableCode {...props} label="Code" block />
         <EditableUrl {...props} label="Url" block />
     </>;
 }

--- a/src/components/semantic/props/EditableText.tsx
+++ b/src/components/semantic/props/EditableText.tsx
@@ -89,7 +89,6 @@ function showErrorIfNotShown(current: EditableTextState) {
 export const EditableText = forwardRef<EditableTextRef, EditableTextProps>(({
                                  text,
                                  onSave: onSaveUnsafe,
-                                 multiLine,
                                  placeHolder,
                                  onDelete: onDeleteUnsafe,
                                  autoFocus,
@@ -99,6 +98,7 @@ export const EditableText = forwardRef<EditableTextRef, EditableTextProps>(({
                                  hideWhenEmpty,
                                  block,
                                  format = "plain",
+                                 multiLine = format === "code",
                                  previewWrapperChar = "",
                                  inputProps,
                              }, ref) => {
@@ -208,7 +208,7 @@ export const EditableText = forwardRef<EditableTextRef, EditableTextProps>(({
     const Wrap = block ? "div" : "span";
     if (state.isEditing) {
         return <Wrap ref={wrapperRef} className={`${styles.isEditingWrapper} ${multiLine ? styles.multiLine : ""}`}>
-            <span className={styles.controlWrapper}>
+            <span className={classNames(styles.controlWrapper, {["w-100"]: format === "code"})}>
                 <span className={styles.labelledInput}>
                     <>
                         {multiLine ? labelElement : <div>{labelElement}</div>}

--- a/src/components/semantic/props/EditableText.tsx
+++ b/src/components/semantic/props/EditableText.tsx
@@ -16,6 +16,7 @@ import { safeLowercase } from "../../../utils/strings";
 import styles from "../styles/editable.module.css";
 import classNames from "classnames";
 import {Markup} from "../../../isaac/markup";
+import CodeMirror, {EditorView} from "@uiw/react-codemirror";
 
 export interface SaveOptions {
     movement?: number;
@@ -211,19 +212,29 @@ export const EditableText = forwardRef<EditableTextRef, EditableTextProps>(({
                 <span className={styles.labelledInput}>
                     <>
                         {multiLine ? labelElement : <div>{labelElement}</div>}
-                        <Input
-                            type={multiLine ? "textarea" : "text"}
-                            /* eslint-disable-next-line jsx-a11y/no-autofocus */
-                            autoFocus
-                            value={state.value ?? ""}
-                            onChange={e => setCurrent(e.target.value)}
-                            onKeyDown={handleKey}
-                            placeholder={placeHolder}
-                            onBlur={onBlur}
-                            invalid={!!errorMessage}
-                            className={format === "code" && styles.codeFormat}
-                            {...inputProps}
-                        />
+                        {format === "code"
+                            ? <CodeMirror
+                                className={"w-100"}
+                                value={state.value ?? ""}
+                                // eslint-disable-next-line jsx-a11y/no-autofocus
+                                autoFocus
+                                extensions={[
+                                    EditorView.lineWrapping,
+                                ]}
+                                onChange={(newValue) => setCurrent(newValue)} />
+                            : <Input
+                                type={multiLine ? "textarea" : "text"}
+                                /* eslint-disable-next-line jsx-a11y/no-autofocus */
+                                autoFocus
+                                value={state.value ?? ""}
+                                onChange={e => setCurrent(e.target.value)}
+                                onKeyDown={handleKey}
+                                placeholder={placeHolder}
+                                onBlur={onBlur}
+                                invalid={!!errorMessage}
+                                {...inputProps}
+                            />
+                        }
                     </>
                 </span>
                 {errorMessage && <FormFeedback className={styles.feedback}>{errorMessage}</FormFeedback>}


### PR DESCRIPTION
Any `EditableDocPropFor` component with `format="code"` now uses CodeMirror for editing rather than a standard textbox