### PR TITLE
Inline/refer to SVGs based on absence/presence of views, disregarding source

### DIFF
--- a/src/components/semantic/presenters/FigurePresenter.tsx
+++ b/src/components/semantic/presenters/FigurePresenter.tsx
@@ -27,7 +27,7 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
     useEffect(() => {
         if (data && data.content) {
             let dataUrl;
-            if (getImageFileType(doc.src) === "svg") {
+            if (getImageFileType(doc.src) === "svg" && getSVGView(doc.src)) {
                 // SVG images may have "views", which can't be included in inline base 64 data, so we will use the
                 // GitHub URL as the source instead
                 dataUrl = githubURLFromGithubData(data, getSVGView(doc.src))
@@ -58,6 +58,7 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
         let type = "image";
         switch (getImageFileType(doc.src)) {
             case "png": type = "image/png"; break;
+            case "svg": type = "image/svg+xml"; break;
             case "jpg": type = "image/jpeg"; break;
         }
 
@@ -65,7 +66,7 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
         return "data:" + type + ";base64," +  b64;
     }
 
-    function githubURLFromGithubData(data: {download_url: string}, svgView?: string) {
+    function githubURLFromGithubData(data: {download_url: string}, svgView?: string | null) {
         // If there is an SVG view, include at the end of the URL
         return svgView ? `${data.download_url}#${svgView}` : data.download_url;
     }
@@ -74,14 +75,19 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
         src = src?.toLowerCase() ?? "";
 
         // remove SVG view, if present
-        src = src.substring(0, src.lastIndexOf('#'))
+        if(src.includes('#')) {
+            src = src.substring(0, src.lastIndexOf('#'))
+        }
 
         return src.substring(src.lastIndexOf(".") + 1)
     }
 
     function getSVGView(src?: string) {
-        src = src?.toLowerCase() ?? "";
-        return src.substring(src.lastIndexOf("#") + 1)
+        if (src && src.includes('#')) {
+            src = src.toLowerCase()
+            return src.substring(src.lastIndexOf("#") + 1)
+        }
+        return null
     }
 
     function selectFile(file: File) {


### PR DESCRIPTION
The logic to handle SVG images effectively assumes they all make use of views, which is not the case for most SVGs in the content repo. This PR changes the logic so that any SVG with a view is handled differently, whereas standard SVG references are inlined as before.