### PR TITLE
Only warn of changing ID of published page, if page is actually published

### DIFF
--- a/src/components/semantic/Metadata.tsx
+++ b/src/components/semantic/Metadata.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, useState } from "react";
+import React, {ChangeEvent, ContextType, useContext, useState} from "react";
 import { Col, Form, FormText, Input, Label, Row } from "reactstrap";
 import { InputType } from "reactstrap/lib/Input";
 
@@ -6,11 +6,12 @@ import { Content } from "../../isaac-data-types";
 
 import { PresenterProps } from "./registry";
 import { MetaItems } from "./metaItems";
+import { AppContext } from "../../App";
 
 import styles from "./styles/metadata.module.css";
 
 export interface MetaOptions {
-    hasWarning?: (value: unknown) => string | undefined;
+    hasWarning?: (value: unknown, context: ContextType<typeof AppContext>) => string | undefined;
     type?: InputType;
     presenter?: React.FunctionComponent<MetaItemPresenterProps>;
     defaultValue?: unknown;
@@ -38,9 +39,9 @@ function getMetaItem(item: MetaItemKey): [string, MetaOptions] {
     return [metaItem, {}];
 }
 
-export function checkWarning(options: MetaOptions | undefined, newValue: unknown, setWarning: (value: (string | undefined)) => void) {
+export function checkWarning(options: MetaOptions | undefined, newValue: unknown, setWarning: (value: (string | undefined)) => void, context: ContextType<typeof AppContext>) {
     if (options?.hasWarning) {
-        const warning = options.hasWarning(newValue);
+        const warning = options.hasWarning(newValue, context);
         if (warning) {
             setWarning(warning);
         } else {
@@ -61,6 +62,7 @@ export type MetaItemPresenterProps<D extends Content = Content> =
 
 export function MetaItemPresenter({doc, update, id, prop, name, options}: MetaItemPresenterProps) {
     const [warning, setWarning] = useState<string>();
+    const context = useContext(AppContext);
 
     const value: string | undefined = doc[prop as keyof Content] as string ?? options?.defaultValue;
 
@@ -69,7 +71,7 @@ export function MetaItemPresenter({doc, update, id, prop, name, options}: MetaIt
         switch (options?.type) {
             case "number": newValue = parseInt(value, 10); break;
         }
-        checkWarning(options, newValue, setWarning);
+        checkWarning(options, newValue, setWarning, context);
         if (options?.deleteIfEmpty && value.replace(/\s/g, "").length === 0) {
             newValue = undefined;
         }

--- a/src/components/semantic/metaItems.tsx
+++ b/src/components/semantic/metaItems.tsx
@@ -20,12 +20,12 @@ const TITLE_MAX_LENGTH = 32;
 export const MetaItems = asMetaItems({
     tags: ["Tags", {presenter: TagsPresenter}],
     id: ["ID", {
-        hasWarning: (value) => {
-            const id = value as string;
+        hasWarning: (newValue, context) => {
+            const id = newValue as string;
             if (!id.match(/^[a-z0-9_-]+$/)) {
-                return "Please alter this ID, as it does not match our required style";
+                return "Please alter this ID, as it does not match our required style (ids can only contain alphanumerics, dashes and underscores)";
             }
-            if (id) {
+            if (id && context.editor.isAlreadyPublished()) {
                 return "Please make sure not to alter the id of content once it has been published";
             }
         }

--- a/src/components/semantic/metaItems.tsx
+++ b/src/components/semantic/metaItems.tsx
@@ -1,4 +1,4 @@
-import React, {useCallback, useEffect, useState} from "react";
+import React, {useCallback, useContext, useEffect, useState} from "react";
 import {Button, Col, FormText, Input, Label, Row} from "reactstrap";
 
 import {Content, ExternalReference, IsaacEventPage, IsaacQuiz, Location,} from "../../isaac-data-types";
@@ -13,6 +13,7 @@ import {asMetaItems, checkWarning, MetaItemPresenter, MetaItemPresenterProps} fr
 
 import styles from "./styles/metadata.module.css";
 import {isDefined} from "../../utils/types";
+import {AppContext} from "../../App";
 
 const TITLE_MAX_LENGTH = 32;
 
@@ -174,6 +175,8 @@ function DateTimeInput({doc, update, prop, options, ...rest}: MetaItemPresenterP
     const dateProp = prop as keyof IsaacEventPage;
     const [warning, setWarning] = useState<string>();
 
+    const context = useContext(AppContext);
+
     function padDigits(num: number) {
         return num.toString().padStart(2, '0');
     }
@@ -190,14 +193,14 @@ function DateTimeInput({doc, update, prop, options, ...rest}: MetaItemPresenterP
     const [dateOutput, setDateOutput] = useState(initialValue);
 
     useEffect(() => {
-        checkWarning(options, initialValue, setWarning);
+        checkWarning(options, initialValue, setWarning, context);
     }, [options, initialValue]);
 
     function onChange(e: React.ChangeEvent<HTMLInputElement>) {
         setDateInput(e.target.value);
         try {
             const d = Date.parse(e.target.value.replace(/-/g, "/"));
-            checkWarning(options, d, setWarning);
+            checkWarning(options, d, setWarning, context);
             if (d) {
                 setDateOutput(dateFilter(new Date(d)));
                 update({...doc, [dateProp]: d});

--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -259,6 +259,7 @@ export async function githubSave(context: ContextType<typeof AppContext>) {
     try {
         const fileJSON = context.editor.getCurrentDoc();
         const alreadyPublished = context.editor.isAlreadyPublished();
+        // TODO if published changing to true, do content error checks beforehand (perhaps via an API service?)
         isPublishedChange = fileJSON.published || alreadyPublished;
         isContent = true;
     } catch {


### PR DESCRIPTION
Involves threading the app context object into `hasWarning` meta item callbacks.