### PR TITLE
Add proper support for the null cloze item placeholder for empty zones

### DIFF
--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -1,5 +1,5 @@
-import React, {MutableRefObject, useContext, useEffect, useRef,} from "react";
-import {Button, Input, Label} from "reactstrap";
+import React, {MutableRefObject, useContext, useEffect, useRef, useState,} from "react";
+import {Alert, Button, Input, Label} from "reactstrap";
 import {InputType} from "reactstrap/lib/Input";
 
 import {
@@ -34,7 +34,7 @@ import {ClozeQuestionContext, ItemsContext} from "./ItemQuestionPresenter";
 import styles from "../styles/choice.module.css";
 import {QuestionContext} from "./questionPresenters";
 import {Markup} from "../../../isaac/markup";
-import {NULL_CLOZE_ITEM} from "../../../isaac/IsaacTypes";
+import {NULL_CLOZE_ITEM, NULL_CLOZE_ITEM_ID} from "../../../isaac/IsaacTypes";
 
 
 interface LabeledInputProps<V extends Record<string, string | undefined>> {
@@ -202,8 +202,11 @@ export const ItemChoicePresenter = (props: ValuePresenterProps<ParsonsChoice>) =
     const {isClozeQuestion, dropZoneCount} = useContext(ClozeQuestionContext);
     const {doc, update} = props;
 
+    const [showClozeChoiceWarning, setShowClozeChoiceWarning] = useState<boolean>(false);
+
     // An update function that augments the choice with null cloze items in empty spaces if this is a cloze question
     const augmentedUpdate = (newDoc: ParsonsChoice) => {
+        setShowClozeChoiceWarning(false); // This augmented update will always fix the cloze subset match warning
         return update(isClozeQuestion && dropZoneCount
             ? {
                 ...newDoc,
@@ -216,17 +219,33 @@ export const ItemChoicePresenter = (props: ValuePresenterProps<ParsonsChoice>) =
     };
     // Ensure that the null cloze items are added to the doc initially for a new choice (again only if this is a cloze question)
     useEffect(() => {
-        if (isClozeQuestion && (!doc.items || doc.items.length === 0)) {
-            augmentedUpdate(doc);
+        if (isClozeQuestion) {
+            if (!doc.items || doc.items.length === 0) {
+                augmentedUpdate(doc);
+            } else if (doc.items.length !== dropZoneCount) {
+                setShowClozeChoiceWarning(true);
+            } else {
+                setShowClozeChoiceWarning(false);
+            }
         }
-    }, []);
+    }, [dropZoneCount]);
 
     const items = maybeItems ?? [];
     const remainingItems = withReplacement ? items : items.filter(item => !doc.items?.find(i => i.id === item.id));
 
     return <>
-        {doc.type === "itemChoice" && <CheckboxDocProp {...props} doc={doc} update={augmentedUpdate} prop="allowSubsetMatch" label="Can match if a subset of the answer" />}
-        <ItemsContext.Provider value={{items, remainingItems, withReplacement}}>
+        {doc.type === "itemChoice" && <CheckboxDocProp {...props} doc={doc} update={props.update} prop="allowSubsetMatch" label="Can match if a subset of the answer" />}
+        {doc.type === "itemChoice" && isClozeQuestion && !doc.allowSubsetMatch && doc.items?.find(i => i.id === NULL_CLOZE_ITEM_ID) && <Alert color={"warning"}>
+            Please fill in all &quot;Any item&quot; placeholders. If you would like to use subset matching, tick the box above.
+        </Alert>}
+        {doc.type === "itemChoice" && showClozeChoiceWarning && <Alert color={"danger"}>
+            In order for cloze questions to work as expected, the choice must be the same length as the number of
+            drop zones, and should contain &quot;Any item&quot; placeholders in slots that should be ignored (if using
+            subset matching).<br/>
+            If a choice does not have the same number of items as drop zones, <b>it will not be checked against the
+            users answer</b>.
+        </Alert>}
+        <ItemsContext.Provider value={{items, remainingItems, withReplacement, allowSubsetMatch: doc.allowSubsetMatch}}>
             <ListPresenterProp {...props} doc={doc} update={augmentedUpdate} prop="items" childTypeOverride="item$choice" />
         </ItemsContext.Provider>
     </>;

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -214,12 +214,9 @@ export const ItemChoicePresenter = (props: ValuePresenterProps<ParsonsChoice>) =
             }
             : newDoc);
     };
-    // Ensure that the null cloze items are added to the doc initially (again only if this is a cloze question)
-    //
-    // This has the extra effect of adding null cloze items to choices in any cloze questions that are visited by
-    // the user, bringing them up to date with the new format.
+    // Ensure that the null cloze items are added to the doc initially for a new choice (again only if this is a cloze question)
     useEffect(() => {
-        if (isClozeQuestion) {
+        if (isClozeQuestion && (!doc.items || doc.items.length === 0)) {
             augmentedUpdate(doc);
         }
     }, []);

--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -105,7 +105,7 @@ export function ItemPresenter(props: PresenterProps<Item>) {
 
 function ItemRow({item}: {item: Item}) {
     return item.id === NULL_CLOZE_ITEM_ID
-        ? <>Empty drop zone</>
+        ? <>Any item</>
         : <Row>
             <Col xs={3}>
                 {item.id}

--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -29,10 +29,11 @@ interface ItemsContextType {
     items: ParsonsItem[] | undefined;
     remainingItems: ParsonsItem[] | undefined;
     withReplacement: boolean | undefined;
+    allowSubsetMatch: boolean | undefined;
 }
 
 export const ItemsContext = createContext<ItemsContextType>(
-    {items: undefined, remainingItems: undefined, withReplacement: undefined}
+    {items: undefined, remainingItems: undefined, withReplacement: undefined, allowSubsetMatch: undefined}
 );
 export const ClozeQuestionContext = createContext<{isClozeQuestion: boolean, dropZoneCount?: number}>(
     {isClozeQuestion: false}
@@ -85,7 +86,8 @@ export function ItemQuestionPresenter(props: PresenterProps<IsaacItemQuestion | 
         <ItemsContext.Provider value={{
             items: doc.items,
             remainingItems: undefined,
-            withReplacement: isClozeQuestion(doc) && doc.withReplacement
+            withReplacement: isClozeQuestion(doc) && doc.withReplacement,
+            allowSubsetMatch: undefined,
         }}>
             <QuestionFooterPresenter {...props} />
         </ItemsContext.Provider>
@@ -127,14 +129,14 @@ const indentationOptions: MetaOptions = {type: "number", hasWarning: (value) => 
 export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
     const {doc, update} = props;
     const [isOpen, setOpen] = useState(false);
-    const {items, remainingItems} = useContext(ItemsContext);
+    const {items, remainingItems, allowSubsetMatch} = useContext(ItemsContext);
     const {isClozeQuestion} = useContext(ClozeQuestionContext);
 
     const item = items?.find((item) => item.id === doc.id) ?? {
         id: doc.id,
         value: "Unknown item",
     };
-    const staticItems = isClozeQuestion && item.id !== NULL_CLOZE_ITEM_ID ? [NULL_CLOZE_ITEM] : [];
+    const staticItems = isClozeQuestion && allowSubsetMatch && item.id !== NULL_CLOZE_ITEM_ID ? [NULL_CLOZE_ITEM] : [];
 
     const dropdown = <Dropdown toggle={() => setOpen(toggle => !toggle)}
                                isOpen={isOpen}>

--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -1,4 +1,4 @@
-import React, {createContext, MouseEventHandler, useContext, useState} from "react";
+import React, {createContext, useContext, useEffect, useState} from "react";
 import {Button, Col, Dropdown, DropdownItem, DropdownMenu, DropdownToggle, Row} from "reactstrap";
 
 import {
@@ -22,6 +22,8 @@ import {MetaItemPresenter, MetaOptions} from "../Metadata";
 import styles from "../styles/question.module.css";
 import {Box} from "../SemanticItem";
 import {ExpandableText} from "../ExpandableText";
+import {extractValueOrChildrenText} from "../../../utils/content";
+import {NULL_CLOZE_ITEM, NULL_CLOZE_ITEM_ID} from "../../../isaac/IsaacTypes";
 
 interface ItemsContextType {
     items: ParsonsItem[] | undefined;
@@ -30,8 +32,11 @@ interface ItemsContextType {
 }
 
 export const ItemsContext = createContext<ItemsContextType>(
-    {items: undefined, remainingItems: undefined, withReplacement: undefined});
-export const ClozeQuestionContext = createContext<boolean>(false);
+    {items: undefined, remainingItems: undefined, withReplacement: undefined}
+);
+export const ClozeQuestionContext = createContext<{isClozeQuestion: boolean, dropZoneCount?: number}>(
+    {isClozeQuestion: false}
+);
 
 function isParsonsQuestion(doc: IsaacParsonsQuestion | IsaacClozeQuestion): doc is IsaacParsonsQuestion {
     return doc.type === "isaacParsonsQuestion";
@@ -44,13 +49,27 @@ function isClozeQuestion(doc: IsaacParsonsQuestion | IsaacClozeQuestion): doc is
 export function ItemQuestionPresenter(props: PresenterProps<IsaacItemQuestion | IsaacReorderQuestion | IsaacParsonsQuestion | IsaacClozeQuestion>) {
     const {doc, update} = props;
 
-    return <>
+    // Logic to count cloze question drop zones (if necessary) on initial presenter render and doc update
+    const [dropZoneCount, setDropZoneCount] = useState<number>();
+    const countDropZonesIn = (doc: IsaacItemQuestion | IsaacReorderQuestion | IsaacParsonsQuestion | IsaacClozeQuestion) => {
+        if (!isClozeQuestion(doc)) return;
+        const dropZoneRegex = /\[drop-zone(?<params>\|(?<width>w-\d+?)?(?<height>h-\d+?)?)?]/g;
+        const questionExposition = extractValueOrChildrenText(doc);
+        setDropZoneCount(questionExposition.match(dropZoneRegex)?.length ?? 0);
+    };
+    const updateWithDropZoneCount = (newDoc: IsaacItemQuestion | IsaacReorderQuestion | IsaacParsonsQuestion | IsaacClozeQuestion) => {
+        update(newDoc);
+        countDropZonesIn(newDoc);
+    };
+    useEffect(() => {
+        countDropZonesIn(doc);
+    }, []);
+
+    return <ClozeQuestionContext.Provider value={{isClozeQuestion: isClozeQuestion(doc), dropZoneCount}}>
         {isParsonsQuestion(doc) && <div><CheckboxDocProp doc={doc} update={update} prop="disableIndentation" label="Disable indentation" /></div>}
         {isClozeQuestion(doc) && <div><CheckboxDocProp doc={doc} update={update} prop="withReplacement" label="Allow items to be used more than once" /></div>}
         <div><CheckboxDocProp doc={doc} update={update} prop="randomiseItems" label="Randomise items on question load" checkedIfUndefined={true} /></div>
-        <ClozeQuestionContext.Provider value={isClozeQuestion(doc)}>
-            <ContentValueOrChildrenPresenter {...props} topLevel />
-        </ClozeQuestionContext.Provider>
+        <ContentValueOrChildrenPresenter {...props} update={updateWithDropZoneCount} topLevel />
         {isClozeQuestion(doc) && <ClozeQuestionInstructions />}
         <Box name="Items">
             <Row className={styles.itemsHeaderRow}>
@@ -63,12 +82,14 @@ export function ItemQuestionPresenter(props: PresenterProps<IsaacItemQuestion | 
             </Row>
             <ListPresenterProp {...props} prop="items" childTypeOverride={isParsonsQuestion(doc) ? "parsonsItem" : "item"} />
         </Box>
-        <ItemsContext.Provider value={
-            {items: doc.items, remainingItems: undefined, withReplacement: isClozeQuestion(doc) && doc.withReplacement}
-        }>
+        <ItemsContext.Provider value={{
+            items: doc.items,
+            remainingItems: undefined,
+            withReplacement: isClozeQuestion(doc) && doc.withReplacement
+        }}>
             <QuestionFooterPresenter {...props} />
         </ItemsContext.Provider>
-    </>;
+    </ClozeQuestionContext.Provider>;
 }
 
 export function ItemPresenter(props: PresenterProps<Item>) {
@@ -83,14 +104,16 @@ export function ItemPresenter(props: PresenterProps<Item>) {
 }
 
 function ItemRow({item}: {item: Item}) {
-    return <Row>
-        <Col xs={3}>
-            {item.id}
-        </Col>
-        <Col xs={9} className={styles.itemRowText}>
-            <ExpandableText text={item.value}/>
-        </Col>
-    </Row>
+    return item.id === NULL_CLOZE_ITEM_ID
+        ? <>Empty drop zone</>
+        : <Row>
+            <Col xs={3}>
+                {item.id}
+            </Col>
+            <Col xs={9} className={styles.itemRowText}>
+                <ExpandableText text={item.value}/>
+            </Col>
+        </Row>;
 }
 
 // Resuse the MetaItemPresenter as it gives a live editable view
@@ -105,11 +128,13 @@ export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
     const {doc, update} = props;
     const [isOpen, setOpen] = useState(false);
     const {items, remainingItems} = useContext(ItemsContext);
+    const {isClozeQuestion} = useContext(ClozeQuestionContext);
 
     const item = items?.find((item) => item.id === doc.id) ?? {
         id: doc.id,
         value: "Unknown item",
     };
+    const staticItems = isClozeQuestion && item.id !== NULL_CLOZE_ITEM_ID ? [NULL_CLOZE_ITEM] : [];
 
     const dropdown = <Dropdown toggle={() => setOpen(toggle => !toggle)}
                                isOpen={isOpen}>
@@ -120,7 +145,7 @@ export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
             <DropdownItem key={item.id} className={styles.dropdownItem} active>
                 <ItemRow item={item} />
             </DropdownItem>
-            {remainingItems?.map((i) => {
+            {remainingItems?.concat(staticItems).map((i) => {
                 return <DropdownItem key={i.id} className={styles.dropdownItem} onClick={() => {
                     update({
                         ...doc,
@@ -151,6 +176,7 @@ export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
 
 export function ItemChoiceItemInserter({insert, position, lengthOfCollection}: InserterProps) {
     const {items, remainingItems} = useContext(ItemsContext);
+    const {dropZoneCount, isClozeQuestion} = useContext(ClozeQuestionContext);
 
     if (!items || !remainingItems) {
         return null; // Shouldn't happen.
@@ -159,9 +185,9 @@ export function ItemChoiceItemInserter({insert, position, lengthOfCollection}: I
     if (position !== lengthOfCollection) {
         return null; // Only include an insert button at the end.
     }
-    const item = remainingItems[0];
-    if (!item) {
-        return null; // No items remaining
+    const item = isClozeQuestion ? NULL_CLOZE_ITEM : remainingItems[0];
+    if (!item || (isClozeQuestion && (!dropZoneCount || lengthOfCollection >= dropZoneCount))) {
+        return null; // No items remaining, or max items reached in choice (in case of cloze question)
     }
     return <Button className={styles.itemsChoiceInserter} color="primary" onClick={() => {
         const newItem: ParsonsItem = {type: item.type, id: item.id};

--- a/src/isaac/IsaacTypes.ts
+++ b/src/isaac/IsaacTypes.ts
@@ -1,4 +1,5 @@
 import { createContext } from "react";
+import {Item} from "../isaac-data-types";
 
 export interface BooleanNotation {
     ENG?: boolean;
@@ -8,3 +9,9 @@ export interface BooleanNotation {
 export const NON_STATIC_FIGURE_FLAG = "NON_STATIC_FIGURE";
 export interface FigureNumbersById {[figureId: string]: number | typeof NON_STATIC_FIGURE_FLAG | undefined}
 export const FigureNumberingContext = createContext<FigureNumbersById>({});
+
+export const NULL_CLOZE_ITEM_ID = "NULL_CLOZE_ITEM" as const;
+export const NULL_CLOZE_ITEM: Item = {
+    type: "item",
+    id: NULL_CLOZE_ITEM_ID
+};

--- a/src/utils/content.ts
+++ b/src/utils/content.ts
@@ -1,0 +1,5 @@
+import {Content} from "../isaac-data-types";
+
+export const extractValueOrChildrenText = (doc: Content): string => {
+    return (doc.value || doc.children?.map(extractValueOrChildrenText).join("\n")) ?? "";
+};


### PR DESCRIPTION
Counts drop zones in the question exposition and prefills choices with `{dropZoneCount}` number of "Any item" (wildcard?) items. When items are deleted they are replaced by a wildcard (or rather they are deleted, and a wildcard is appended to the end of the choice).
Effectively stops the user from creating cloze question choices with the wrong number of items, and makes sure they are in the format that the cloze question (back|front)end code can handle.