### PR TITLE
Undo button

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@uiw/react-codemirror": "~4.7.0",
     "bootstrap": "^4.6.1",
     "classnames": "^2.3.1",
+    "fast-json-patch": "^3.1.1",
     "he": "^1.2.0",
     "js-cookie": "^3.0.1",
     "katex": "^0.15.1",

--- a/src/components/SemanticEditor.tsx
+++ b/src/components/SemanticEditor.tsx
@@ -19,8 +19,8 @@ export interface EditorState {
     getCurrentDocAsString: () => string;
     getCurrentDocPath: () => string | undefined;
     setDirty: (isDirty: boolean) => void;
-    setCurrentDoc: (newContent: Content|string) => void;
-    loadNewDoc: (newContent: Content|string) => void;
+    setCurrentDoc: (newContent: Content | string, invertible?: boolean) => void;
+    loadNewDoc: (newContent: Content | string) => void;
     isAlreadyPublished: () => boolean;
 }
 
@@ -80,8 +80,8 @@ export function SemanticEditor() {
     return <div className={styles.editorWrapper}>
         <TopMenu previewable undoable />
         <div className={styles.editorScroller}>
-            <SemanticRoot doc={appContext.editor.getCurrentDoc()} update={(newContent) => {
-                appContext.editor.setCurrentDoc(newContent);
+            <SemanticRoot doc={appContext.editor.getCurrentDoc()} update={(newContent, invertible) => {
+                appContext.editor.setCurrentDoc(newContent, invertible);
             }} />
         </div>
     </div>;

--- a/src/components/SemanticEditor.tsx
+++ b/src/components/SemanticEditor.tsx
@@ -13,6 +13,8 @@ import { TopMenu } from "./TopMenu";
 
 export interface EditorState {
     getDirty: () => boolean;
+    canUndo: () => boolean;
+    undo: () => void;
     getCurrentDoc: () => Content;
     getCurrentDocAsString: () => string;
     getCurrentDocPath: () => string | undefined;
@@ -24,6 +26,10 @@ export interface EditorState {
 
 export const defaultEditorState: EditorState = {
     getDirty: () => false,
+    canUndo: () => false,
+    undo: () => {
+        throw new Error("undo called outside of AppContent");
+    },
     getCurrentDoc: () => ({}),
     getCurrentDocAsString: () => "",
     getCurrentDocPath: () => undefined,
@@ -72,7 +78,7 @@ export function SemanticEditor() {
     }
 
     return <div className={styles.editorWrapper}>
-        <TopMenu previewable />
+        <TopMenu previewable undoable />
         <div className={styles.editorScroller}>
             <SemanticRoot doc={appContext.editor.getCurrentDoc()} update={(newContent) => {
                 appContext.editor.setCurrentDoc(newContent);

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -35,7 +35,7 @@ function getPreviewLink(doc: Content) {
     }
 }
 
-export function TopMenu({previewable}: {previewable?: boolean}) {
+export function TopMenu({previewable, undoable}: {previewable?: boolean; undoable?: boolean}) {
     const menuRef = useRef<PopupMenuRef>(null);
     const appContext = useContext(AppContext);
 
@@ -57,6 +57,9 @@ export function TopMenu({previewable}: {previewable?: boolean}) {
         {appContext.editor.getDirty() &&
             <button className={styles.iconButton} onClick={() => appContext.dispatch({"type": "save"})}>
                 💾<span className="d-none d-lg-inline"> Save</span>
+            </button>}
+        {undoable && appContext.editor.canUndo() && <button className={styles.iconButton} onClick={appContext.editor.undo}>
+                ↺<span className="d-none d-lg-inline"> Undo</span>
             </button>}
         {selection && !selection.isDir && previewLink && <button onClick={() => window.open(previewLink, "_blank")} className={styles.iconButton} >
             Staging

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -9,6 +9,7 @@ import {Entry} from "./FileBrowser";
 import styles from "../styles/editor.module.css";
 import {Content} from "../isaac-data-types";
 import {StagingServer} from "../services/isaacApi";
+import classNames from "classnames";
 
 function filePathToEntry(path: string | undefined, sha: string): Entry {
     const name = path?.substring(path?.lastIndexOf("/") + 1) ?? "";
@@ -58,7 +59,7 @@ export function TopMenu({previewable, undoable}: {previewable?: boolean; undoabl
             <button className={styles.iconButton} onClick={() => appContext.dispatch({"type": "save"})}>
                 💾<span className="d-none d-lg-inline"> Save</span>
             </button>}
-        {undoable && appContext.editor.canUndo() && <button className={styles.iconButton} onClick={appContext.editor.undo}>
+        {undoable && appContext.editor.canUndo() && <button className={classNames(styles.iconButton, styles.undoButton)} onClick={appContext.editor.undo}>
                 ↺<span className="d-none d-lg-inline"> Undo</span>
             </button>}
         {selection && !selection.isDir && previewLink && <button onClick={() => window.open(previewLink, "_blank")} className={styles.iconButton} >

--- a/src/components/semantic/SemanticItem.tsx
+++ b/src/components/semantic/SemanticItem.tsx
@@ -60,7 +60,7 @@ interface Metadata {
 
 export interface SemanticItemProps<D extends Content = Content> {
     doc: D;
-    update: (newContent: D) => void;
+    update: (newContent: D, invertible?: boolean) => void;
     onDelete?: () => void;
     name?: string;
     className?: string;

--- a/src/components/semantic/SemanticRoot.tsx
+++ b/src/components/semantic/SemanticRoot.tsx
@@ -9,7 +9,7 @@ import styles from "./styles/semantic.module.css";
 
 interface SemanticRootProps {
     doc: Content;
-    update: (newContent: Content) => void;
+    update: (newContent: Content, invertible?: boolean) => void;
 }
 
 

--- a/src/components/semantic/presenters/BaseValuePresenter.tsx
+++ b/src/components/semantic/presenters/BaseValuePresenter.tsx
@@ -1,4 +1,12 @@
-import React, {FunctionComponent, MutableRefObject, useCallback, useImperativeHandle, useRef, useState} from "react";
+import React, {
+    FunctionComponent,
+    MutableRefObject,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+    useState
+} from "react";
 import CodeMirror, {EditorView, ReactCodeMirrorRef} from '@uiw/react-codemirror';
 import {markdown} from '@codemirror/lang-markdown';
 import {html} from '@codemirror/lang-html';

--- a/src/components/semantic/presenters/BaseValuePresenter.tsx
+++ b/src/components/semantic/presenters/BaseValuePresenter.tsx
@@ -1,12 +1,4 @@
-import React, {
-    FunctionComponent,
-    MutableRefObject,
-    useCallback,
-    useEffect,
-    useImperativeHandle,
-    useRef,
-    useState
-} from "react";
+import React, {FunctionComponent, MutableRefObject, useCallback, useImperativeHandle, useRef, useState} from "react";
 import CodeMirror, {EditorView, ReactCodeMirrorRef} from '@uiw/react-codemirror';
 import {markdown} from '@codemirror/lang-markdown';
 import {html} from '@codemirror/lang-html';

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -205,7 +205,7 @@ export const ItemChoicePresenter = (props: ValuePresenterProps<ParsonsChoice>) =
     const [showClozeChoiceWarning, setShowClozeChoiceWarning] = useState<boolean>(false);
 
     // An update function that augments the choice with null cloze items in empty spaces if this is a cloze question
-    const augmentedUpdate = (newDoc: ParsonsChoice) => {
+    const augmentedUpdate = (newDoc: ParsonsChoice, invertible?: boolean) => {
         setShowClozeChoiceWarning(false); // This augmented update will always fix the cloze subset match warning
         return update(isClozeQuestion && dropZoneCount
             ? {
@@ -215,7 +215,8 @@ export const ItemChoicePresenter = (props: ValuePresenterProps<ParsonsChoice>) =
                     : nci
                 )
             }
-            : newDoc);
+            : newDoc
+            , invertible);
     };
     // Ensure that the null cloze items are added to the doc initially for a new choice (again only if this is a cloze question)
     useEffect(() => {

--- a/src/components/semantic/presenters/ContentValueOrChildrenPresenter.tsx
+++ b/src/components/semantic/presenters/ContentValueOrChildrenPresenter.tsx
@@ -10,18 +10,18 @@ import { useFixedRef } from "../../../utils/hooks";
 function PromotableValuePresenter({doc: baseDoc, update: baseUpdate}: ValuePresenterProps) {
     const docRef = useFixedRef(baseDoc);
     const doc = useMemo(() => ({type: "content", children: [{type: "content", encoding: baseDoc.encoding, value: baseDoc.value}]}), [baseDoc]);
-    const update = useCallback((newContent: Content) => {
+    const update = useCallback((newContent: Content, invertible?: boolean) => {
         if (newContent.children?.length === 1) {
             baseUpdate({
                 ...docRef.current,
                 value: (newContent.children[0] as Content).value,
-            });
+            }, invertible);
         } else {
             baseUpdate({
                 ...docRef.current,
                 value: undefined,
                 children: newContent.children,
-            });
+            }, invertible);
         }
     }, [baseUpdate, docRef]);
 

--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -58,8 +58,8 @@ export function ItemQuestionPresenter(props: PresenterProps<IsaacItemQuestion | 
         const questionExposition = extractValueOrChildrenText(doc);
         setDropZoneCount(questionExposition.match(dropZoneRegex)?.length ?? 0);
     };
-    const updateWithDropZoneCount = (newDoc: IsaacItemQuestion | IsaacReorderQuestion | IsaacParsonsQuestion | IsaacClozeQuestion) => {
-        update(newDoc);
+    const updateWithDropZoneCount = (newDoc: IsaacItemQuestion | IsaacReorderQuestion | IsaacParsonsQuestion | IsaacClozeQuestion, invertible?: boolean) => {
+        update(newDoc, invertible);
         countDropZonesIn(newDoc);
     };
     useEffect(() => {

--- a/src/components/semantic/presenters/ListChildrenPresenter.tsx
+++ b/src/components/semantic/presenters/ListChildrenPresenter.tsx
@@ -67,7 +67,7 @@ interface ListChildProps {
     child: Content;
     index: number;
     shiftBy: (index: number, amount: number) => void;
-    updateChild: (index: number, newValue: Content) => void;
+    updateChild: (index: number, newValue: Content, invertible?: boolean) => void;
     remove: (index: number) => void;
     typeOverride: ContentType | undefined;
 }

--- a/src/components/semantic/presenters/TabsPresenter.tsx
+++ b/src/components/semantic/presenters/TabsPresenter.tsx
@@ -78,11 +78,6 @@ type TabsMainProps = TabsProps & {
 
 export function TabsMain({docRef, currentChild, updateCurrentChild, doRemove, doShift, keyList, index, emptyDescription, elementName, styles, suppressHeaderNames, showTitles, back, forward, contentHeader, extraButtons}: TabsMainProps) {
     const elementNameLC = safeLowercase(elementName);
-    const doDelete = useCallback(() => {
-        if (window.confirm(`Are you sure you want to delete this ${elementNameLC}?`)) {
-            doRemove();
-        }
-    }, [elementNameLC, doRemove]);
 
     return <div className={styles.main}>
         {currentChild && <React.Fragment key={keyList[index]}>
@@ -97,7 +92,7 @@ export function TabsMain({docRef, currentChild, updateCurrentChild, doRemove, do
                         {forward}
                     </Button>
                 </ButtonGroup>
-                <Button size="sm" color="danger" onClick={doDelete}>Delete {elementNameLC}</Button>
+                <Button size="sm" color="danger" onClick={doRemove}>Delete {elementNameLC}</Button>
             </div>
             {contentHeader}
             <SemanticItem className={styles.hideMargins} doc={currentChild} update={updateCurrentChild}/>

--- a/src/components/semantic/presenters/pagePresenters.tsx
+++ b/src/components/semantic/presenters/pagePresenters.tsx
@@ -20,7 +20,7 @@ export function QuizPagePresenter(props: PresenterProps<IsaacQuiz>) {
     return <>
         <PagePresenter {...props} />
         {props.doc.rubric ?
-            <SemanticDocProp {...props} prop="rubric" name="Rubric" onDelete={() => props.update({...props.doc, rubric: undefined})} /> :
+            <SemanticDocProp {...props} prop="rubric" name="Rubric" onDelete={() => props.update({...props.doc, rubric: undefined}, true)} /> :
             <Button color="secondary" outline onClick={() => props.update({...props.doc, rubric: (EMPTY_DOCUMENTS['isaacQuiz'] as IsaacQuiz).rubric})}>
                 Add rubric
             </Button>}

--- a/src/components/semantic/props/SemanticDocProp.tsx
+++ b/src/components/semantic/props/SemanticDocProp.tsx
@@ -19,11 +19,11 @@ const emptyContent = {
 export const SemanticDocProp = <K extends string, D extends Content>({doc, update, prop, ...rest}: SemanticDocProps<K, D>) => {
     const subDoc = doc[prop] as Content ?? emptyContent;
     const docRef = useFixedRef(doc);
-    const childUpdate = useCallback((newContent: Content) => {
+    const childUpdate = useCallback((newContent: Content, invertible?: boolean) => {
         update({
             ...docRef.current,
             [prop]: newContent,
-        });
+        }, invertible);
     }, [docRef, update, prop]);
     return <SemanticItem doc={subDoc} update={childUpdate} {...rest} />;
 };

--- a/src/components/semantic/props/listProps.tsx
+++ b/src/components/semantic/props/listProps.tsx
@@ -37,12 +37,11 @@ function useTypedListExtractor<T>({doc, update, prop, type}: ListExtractorProps<
         };
     }, [doc, prop, type]);
 
-    const updateChild = useCallback((newContent: Content) => {
+    const updateChild = useCallback((newContent: Content, invertible?: boolean) => {
         update({
-                ...docRef.current,
-                [prop]: newContent.children
-            }
-        );
+            ...docRef.current,
+            [prop]: newContent.children
+        }, invertible);
     }, [docRef, prop, update]);
     return {doc: child, update: updateChild};
 }

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -69,7 +69,7 @@ export type ContentType =
 
 export interface PresenterProps<D = Content> {
     doc: D;
-    update: <T extends D>(newContent: T) => void;
+    update: <T extends D>(newContent: T, invertible?: boolean) => void;
 }
 
 export type Presenter<D extends Content = Content> = FunctionComponent<PresenterProps<D>>;

--- a/src/screens/EditorScreen.tsx
+++ b/src/screens/EditorScreen.tsx
@@ -122,7 +122,6 @@ export function EditorScreen() {
     const setCurrentDoc = useCallback((content: Content | string, invertible = false) => {
         if (invertible) {
             const currentLastChanges = compare(currentContent, content, true);
-            console.log(currentLastChanges);
             setLastChange(prevLastChanges => currentLastChanges.length > 0 ? currentLastChanges : prevLastChanges);
         }
         setCurrentContent(content);
@@ -155,7 +154,12 @@ export function EditorScreen() {
                 canUndo: () => isDefined(lastChange) && lastChange.length > 0,
                 undo: () => {
                     if (lastChange) {
-                        setCurrentDoc(inverseOperation(lastChange).reduce(applyReducer, currentContent));
+                        try {
+                            const contentAfterUndo = inverseOperation(lastChange).reduce(applyReducer, currentContent);
+                            setCurrentDoc(contentAfterUndo);
+                        } catch (e) {
+                            console.error("Could not undo: ", e);
+                        }
                         setLastChange(undefined);
                     }
                 },

--- a/src/screens/EditorScreen.tsx
+++ b/src/screens/EditorScreen.tsx
@@ -19,7 +19,7 @@ import {buildPageError} from "../components/PageError";
 import Split from "react-split";
 import {CDNUploadModal} from "../components/CDNUploadModal";
 import {compare, Operation, applyReducer} from "fast-json-patch";
-import {inverseOperation} from "../utils/inversePatch";
+import {invertJSONPatch} from "../utils/inversePatch";
 
 import styles from "../styles/editor.module.css";
 import {isDefined} from "../utils/types";
@@ -155,7 +155,7 @@ export function EditorScreen() {
                 undo: () => {
                     if (lastChange) {
                         try {
-                            const contentAfterUndo = inverseOperation(lastChange).reduce(applyReducer, currentContent);
+                            const contentAfterUndo = invertJSONPatch(lastChange).reduce(applyReducer, currentContent);
                             setCurrentDoc(contentAfterUndo);
                         } catch (e) {
                             console.error("Could not undo: ", e);

--- a/src/styles/editor.module.css
+++ b/src/styles/editor.module.css
@@ -207,6 +207,18 @@
     background: #eee;
 }
 
+@keyframes flash {
+    0%   { filter: drop-shadow(0 0 0.75rem #ff000000); }
+    50%  { filter: drop-shadow(0 0 0.75rem #ff000055); }
+    100% { filter: drop-shadow(0 0 0.75rem #ff000000); }
+}
+
+.undoButton {
+    animation-name: flash;
+    animation-iteration-count: 2;
+    animation-duration: 2s;
+}
+
 .actionsModalContent {
     height: calc(100vh - 3.5rem);
     background: none;

--- a/src/utils/inversePatch.ts
+++ b/src/utils/inversePatch.ts
@@ -1,0 +1,110 @@
+import {
+    AddOperation,
+    CopyOperation,
+    MoveOperation,
+    Operation,
+    RemoveOperation,
+    ReplaceOperation, TestOperation
+} from "fast-json-patch";
+
+// Adapted from https://github.com/cujojs/jiff
+
+const inverses = {
+    test: invertTest,
+    add: invertAdd,
+    replace: invertReplace,
+    remove: invertRemove,
+    move: invertMove,
+    copy: invertCopy
+};
+
+export function inverseOperation(p: Operation[]) {
+    let pr: Operation[] = [];
+    let c: any, i: number, inverse, skip = 0;
+    for(i = p.length - 1; i>= 0; i -= skip) {
+        c = p[i] as any;
+        inverse = inverses[c.op as keyof typeof inverses];
+        if(typeof inverse === 'function') {
+            skip = inverse(pr, c, i, p);
+        }
+    }
+    return pr;
+}
+
+function invertTest(pr: Operation[], c: TestOperation<any>) {
+    pr.push(c);
+    return 1;
+}
+
+function invertAdd(pr: Operation[], c: AddOperation<any>) {
+    pr.push({
+        op: 'test',
+        path: c.path,
+        value: c.value
+    });
+
+    pr.push({
+        op: 'remove',
+        path: c.path
+    });
+
+    return 1;
+}
+
+function invertReplace(pr: Operation[], c: ReplaceOperation<any>, i: number, p: Operation[]) {
+    let prev = p[i-1];
+    if(prev === void 0 || prev.op !== 'test' || prev.path !== c.path) {
+        throw new Error('cannot invert replace w/o test');
+    }
+
+    pr.push({
+        op: 'test',
+        path: prev.path,
+        value: c.value
+    });
+
+    pr.push({
+        op: 'replace',
+        path: prev.path,
+        value: prev.value
+    });
+
+    return 2;
+}
+
+function invertRemove(pr: Operation[], c: RemoveOperation, i: number, p: Operation[]) {
+    let prev = p[i-1];
+    if (prev === void 0 || prev.op !== 'test' || prev.path !== c.path) {
+        throw new Error('cannot invert remove w/o test');
+    }
+
+    pr.push({
+        op: 'add',
+        path: prev.path,
+        value: prev.value
+    });
+
+    return 2;
+}
+
+function invertMove(pr: Operation[], c: MoveOperation) {
+    pr.push({
+        op: 'move',
+        path: c.from,
+        from: c.path
+    });
+
+    return 1;
+}
+
+function invertCopy(pr: Operation[], c: CopyOperation) {
+    // See https://github.com/cujojs/jiff/issues/9
+    // This needs more thought. We may have to extend/amend JSON Patch.
+    // At first glance, this seems like it should just be a remove.
+    // However, that's not correct.  It violates the involution:
+    // invert(invert(p)) ~= p.  For example:
+    // invert(copy) -> remove
+    // invert(remove) -> add (DOH! this should be copy!)
+    throw new Error('cannot invert copy');
+    return 0;
+}

--- a/src/utils/keyedListHook.ts
+++ b/src/utils/keyedListHook.ts
@@ -10,7 +10,7 @@ let keyBase = 0;
 const createKey = (_: unknown, index: number) => `@${index}: ${++keyBase}`;
 const UNINITIALISED = [] as string[];
 
-export function useKeyedList<T, D>(items: T[] | undefined, deriveNewList: () => [D, T[]], update: (newDoc: D) => void) {
+export function useKeyedList<T, D>(items: T[] | undefined, deriveNewList: () => [D, T[]], update: (newDoc: D, invertible?: boolean) => void) {
     const keyList = useRef(UNINITIALISED);
     if (keyList.current === UNINITIALISED) {
         // We only want to do this pre-mount, and then we manually keep this up to date after that.
@@ -38,7 +38,7 @@ export function useKeyedList<T, D>(items: T[] | undefined, deriveNewList: () => 
             const [newDoc, newList] = deriveNewList();
             newList.splice(index, 1);
             keyList.current.splice(index, 1);
-            update(newDoc);
+            update(newDoc, true);
         }, [deriveNewList, update]),
         shiftBy: useCallback((index: number, amount: number) => {
             const [newDoc, newList] = deriveNewList();
@@ -48,10 +48,10 @@ export function useKeyedList<T, D>(items: T[] | undefined, deriveNewList: () => 
             keyList.current.splice(index, 0, k);
             update(newDoc);
         }, [deriveNewList, update]),
-        updateChild: useCallback((index: number, newValue: T) => {
+        updateChild: useCallback((index: number, newValue: T, invertible?: boolean) => {
             const [newDoc, newList] = deriveNewList();
             newList[index] = newValue;
-            update(newDoc);
+            update(newDoc, invertible);
         }, [deriveNewList, update]),
         keyList: keyList.current,
     };

--- a/yarn.lock
+++ b/yarn.lock
@@ -6252,11 +6252,6 @@ jest@^27.4.3:
     import-local "^3.0.2"
     jest-cli "^27.5.1"
 
-jiff@^0.7.3:
-  version "0.7.3"
-  resolved "https://registry.yarnpkg.com/jiff/-/jiff-0.7.3.tgz#42db5d9140f1804399bb501747055a9434f40f46"
-  integrity sha512-MAo1DhUJTPPFcC+oY80dLHCcHdliFRJyNKn9o3AjImnNWyeA7bALsFbvmN+1Dv5eGTcEMBz3in3ENgvQsNTp5g==
-
 js-cookie@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-3.0.1.tgz#9e39b4c6c2f56563708d7d31f6f5f21873a92414"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4836,6 +4836,11 @@ fast-glob@^3.2.11, fast-glob@^3.2.9:
     merge2 "^1.3.0"
     micromatch "^4.0.4"
 
+fast-json-patch@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/fast-json-patch/-/fast-json-patch-3.1.1.tgz#85064ea1b1ebf97a3f7ad01e23f9337e72c66947"
+  integrity sha512-vf6IHUX2SBcA+5/+4883dsIjpBTqmfBjmYiWK1savxQmFk4JfBMLa7ynTYOs1Rolp/T1betJxHiGD3g1Mn8lUQ==
+
 fast-json-stable-stringify@^2.0.0, fast-json-stable-stringify@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz#874bf69c6f404c2b5d99c481341399fd55892633"
@@ -6246,6 +6251,11 @@ jest@^27.4.3:
     "@jest/core" "^27.5.1"
     import-local "^3.0.2"
     jest-cli "^27.5.1"
+
+jiff@^0.7.3:
+  version "0.7.3"
+  resolved "https://registry.yarnpkg.com/jiff/-/jiff-0.7.3.tgz#42db5d9140f1804399bb501747055a9434f40f46"
+  integrity sha512-MAo1DhUJTPPFcC+oY80dLHCcHdliFRJyNKn9o3AjImnNWyeA7bALsFbvmN+1Dv5eGTcEMBz3in3ENgvQsNTp5g==
 
 js-cookie@^3.0.1:
   version "3.0.1"


### PR DESCRIPTION
If we want to have a general "undo anything" button, there's a weird edge case with `PromotableValuePresenter` (I think) - when "Undo" is pressed, the presenter doesn't update its displayed value, but does if you force it to re-render another way. 

Because of this annoying edge case, I've made it so that actions are only recorded as "undoable" at the level of whatever calls `update`, i.e. the accordion section deletion function passes a flag to `update` saying "allow this action to be undone".
As a rule of thumb structural changes (deleting or moving tabs, accordion sections, content blocks etc.) can be undone without any problems (as far as I can tell).

Currently only deletions are marked as invertible, and only one "last action" is recorded at a time.

I've added a flash to the undo button when it appears. Adding a toast the first time you delete something pointing out that the button exists might be nice, but I didn't feel it was necessary? Open to thoughts on this!