### PR TITLE
Add "Save" and "Cancel" options to toolbars in all CodeMirror editors

### DIFF
--- a/src/components/MarkupToolbar.tsx
+++ b/src/components/MarkupToolbar.tsx
@@ -20,6 +20,7 @@ export const MarkupToolbar = ({set, cancel, codemirror, encoding}: { set: () => 
     const [wide, setWide] = useState(true);
     const toolbarRef = useRef<HTMLDivElement>(null);
 
+    // TODO should be replaced by `useDeviceSize` (from isaac-react-app)
     const updateIsWide = useCallback(() => {
         const MIN_WIDTH = 500;
         const width = toolbarRef.current?.clientWidth;

--- a/src/components/MarkupToolbar.tsx
+++ b/src/components/MarkupToolbar.tsx
@@ -1,4 +1,4 @@
-import React, {RefObject, useContext} from "react";
+import React, {RefObject, useCallback, useContext, useEffect, useLayoutEffect, useRef, useState} from "react";
 import {ReactCodeMirrorRef} from "@uiw/react-codemirror";
 import {PopupGlossaryTermSelect} from "./popups/PopupGlossaryTermSelect";
 import {PopupDropZoneInsert} from "./popups/PopupDropZoneInsert";
@@ -14,10 +14,41 @@ import {
 } from "../utils/codeMirrorExtensions";
 import {ClozeQuestionContext} from "./semantic/presenters/ItemQuestionPresenter";
 
-export const MarkupToolbar = ({codemirror, encoding}: { codemirror: RefObject<ReactCodeMirrorRef>, encoding: string | undefined }) => {
+export const MarkupToolbar = ({set, cancel, codemirror, encoding}: { set: () => void, cancel: () => void, codemirror?: RefObject<ReactCodeMirrorRef>, encoding: string | undefined }) => {
     const inClozeQuestion = useContext(ClozeQuestionContext);
-    if (isMarkupEncoding(encoding)) {
-        return <div className={"d-flex w-100 bg-light border-bottom p-1 " + styles.cmMenuBar}>
+
+    const [wide, setWide] = useState(true);
+    const toolbarRef = useRef<HTMLDivElement>(null);
+
+    const updateIsWide = useCallback(() => {
+        const MIN_WIDTH = 500;
+        const width = toolbarRef.current?.clientWidth;
+        setWide(!width || width >= MIN_WIDTH);
+    }, []);
+
+    useLayoutEffect(() => {
+        updateIsWide();
+    }, []);
+
+    useEffect(() => {
+        if (!toolbarRef.current) return;
+        const resizeObserver = new ResizeObserver(updateIsWide);
+        resizeObserver.observe(toolbarRef.current);
+        return () => resizeObserver.disconnect();
+    }, []);
+
+    return <div ref={toolbarRef} className={"d-flex w-100 bg-light border-bottom p-1 " + styles.cmMenuBar}>
+        <button className={styles.cmPanelButton} title={"Set (Mod-Shift-Enter)"}
+                aria-label={"Save changes to this markup block (shortcut is Mod-Shift-Enter)"}
+                onClick={set}>
+            💾{wide && " Set"}
+        </button>
+        <button className={styles.cmPanelButton} title={"Cancel (Esc)"}
+                aria-label={"Cancel changes to this markup block (shortcut is Esc)"}
+                onClick={cancel}>
+            ❌{wide && " Cancel"}
+        </button>
+        {isMarkupEncoding(encoding) && codemirror?.current && <>
             <button className={"ml-auto " + styles.cmPanelButton} title={"Bold (Ctrl-B)"}
                     aria-label={"Make highlighted text bold (shortcut is Ctrl-B)"}
                     onClick={() => makeBold(encoding)(codemirror.current?.view)}>
@@ -40,13 +71,12 @@ export const MarkupToolbar = ({codemirror, encoding}: { codemirror: RefObject<Re
             </button>
             {encodingSpecific(
                 <>
-                    {inClozeQuestion && <PopupDropZoneInsert codemirror={codemirror}/>}
-                    {SITE === "CS" && <PopupGlossaryTermSelect codemirror={codemirror}/>}
+                    {inClozeQuestion && <PopupDropZoneInsert wide={wide} codemirror={codemirror}/>}
+                    {SITE === "CS" && <PopupGlossaryTermSelect wide={wide} codemirror={codemirror}/>}
                 </>,
                 null,
                 encoding
             )}
-        </div>;
-    }
-    return null;
+        </>}
+    </div>;
 }

--- a/src/components/TopMenu.tsx
+++ b/src/components/TopMenu.tsx
@@ -50,12 +50,12 @@ export function TopMenu({previewable}: {previewable?: boolean}) {
     }
 
     return <div className={styles.topMenuWrapper}>
-        <button className={styles.iconButton} onClick={(event) => selection && menuRef.current?.open(event, filePathToEntry(selection.path, data.sha))}>
+        <button title={"Open menu"} className={styles.iconButton} onClick={(event) => selection && menuRef.current?.open(event, filePathToEntry(selection.path, data.sha))}>
             ☰<span className="d-none d-lg-inline"> Menu</span>
         </button>
         <div className={styles.flexFill} />
         {appContext.editor.getDirty() &&
-            <button className={styles.iconButton} onClick={() => appContext.dispatch({"type": "save"})}>
+            <button title={"Save changes"} className={styles.iconButton} onClick={() => appContext.dispatch({"type": "save"})}>
                 💾<span className="d-none d-lg-inline"> Save</span>
             </button>}
         {selection && !selection.isDir && previewLink && <button onClick={() => window.open(previewLink, "_blank")} className={styles.iconButton} >

--- a/src/components/popups/PopupDropZoneInsert.tsx
+++ b/src/components/popups/PopupDropZoneInsert.tsx
@@ -4,7 +4,7 @@ import {Button, Container, Input, InputGroup, Label} from "reactstrap";
 import {ReactCodeMirrorRef} from "@uiw/react-codemirror";
 import styles from "../../styles/editor.module.css";
 
-export const PopupDropZoneInsert = ({codemirror}: { codemirror: RefObject<ReactCodeMirrorRef> }) => {
+export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemirror: RefObject<ReactCodeMirrorRef> }) => {
     const popupRef = useRef<PopupRef>(null);
 
     const [width, setWidth] = useState<number>();
@@ -31,9 +31,9 @@ export const PopupDropZoneInsert = ({codemirror}: { codemirror: RefObject<ReactC
     }
 
     return <>
-        <button className={styles.cmPanelButton} title={"Insert cloze drop zone"} onClick={(event) => {
+        <button className={styles.cmPanelButton} title={"Insert cloze drop-zone"} onClick={(event) => {
             popupRef.current?.open(event);
-        }}>Add cloze drop zone</button>
+        }}>{wide ? "Add cloze drop-zone" : "➕ drop-zone"}</button>
         <Popup popUpRef={popupRef}>
             <Container className={styles.cmPanelPopup}>
                 <Label for={"drop-zone-width"}>Width:</Label>

--- a/src/components/popups/PopupGlossaryTermSelect.tsx
+++ b/src/components/popups/PopupGlossaryTermSelect.tsx
@@ -10,7 +10,7 @@ import Select from "react-select";
 import {Item} from "../../utils/select";
 import {isDefined} from "../../utils/types";
 
-export const PopupGlossaryTermSelect = ({codemirror}: { codemirror: RefObject<ReactCodeMirrorRef> }) => {
+export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, codemirror: RefObject<ReactCodeMirrorRef> }) => {
     const popupRef = useRef<PopupRef>(null);
 
     const {data: glossaryTerms} = useSWR<{results: GlossaryTerm[]}>(
@@ -38,7 +38,7 @@ export const PopupGlossaryTermSelect = ({codemirror}: { codemirror: RefObject<Re
     return <>
         <button className={styles.cmPanelButton} title={"Insert glossary term"} onClick={(event) => {
             popupRef.current?.open(event);
-        }}>Add glossary term</button>
+        }}>{wide ? "Add glossary term" : "➕ glossary"}</button>
         <Popup popUpRef={popupRef}>
             <Container className={styles.cmPanelPopup}>
                 <Label for={"glossary-term-id-select"}>Select glossary term:</Label>

--- a/src/components/semantic/JSONEditor.tsx
+++ b/src/components/semantic/JSONEditor.tsx
@@ -7,6 +7,7 @@ import {linter, lintGutter} from "@codemirror/lint";
 import {PresenterProps} from "./registry";
 import styles from "./styles/semantic.module.css";
 import {keyBindings, spellchecker} from "../../utils/codeMirrorExtensions";
+import {MarkupToolbar} from "../MarkupToolbar";
 
 const extensions = [json(), EditorView.lineWrapping, linter(jsonParseLinter()), lintGutter(), rectangularSelection(), spellchecker()];
 const empty = Symbol("empty") as unknown as string;
@@ -45,7 +46,9 @@ export function JSONEditor({doc, update, close}: PresenterProps & { close: () =>
                     setValid(false);
                 }
             }}
-        />
+        >
+            <MarkupToolbar set={setDocChanges} cancel={cancelDocChanges} encoding={doc.encoding} />
+        </CodeMirror>
         <div className={`mt-2 ${styles.editButtons}`}>
             <Button onClick={cancelDocChanges}>Cancel</Button>
             <Button color="primary" disabled={!valid} onClick={setDocChanges}>Set</Button>

--- a/src/components/semantic/presenters/BaseValuePresenter.tsx
+++ b/src/components/semantic/presenters/BaseValuePresenter.tsx
@@ -127,7 +127,7 @@ export const BaseValue = ({doc, editing, value, set, cancel}: ValueProps<string 
                 value.current = newValue;
             }}
         >
-            <MarkupToolbar codemirror={codemirror} encoding={doc.encoding} />
+            <MarkupToolbar set={set} cancel={cancel} codemirror={codemirror} encoding={doc.encoding} />
         </CodeMirror>;
     }
 };

--- a/src/components/semantic/props/EditableText.tsx
+++ b/src/components/semantic/props/EditableText.tsx
@@ -17,6 +17,8 @@ import styles from "../styles/editable.module.css";
 import classNames from "classnames";
 import {Markup} from "../../../isaac/markup";
 import CodeMirror, {EditorView} from "@uiw/react-codemirror";
+import {MarkupToolbar} from "../../MarkupToolbar";
+import {keyBindings} from "../../../utils/codeMirrorExtensions";
 
 export interface SaveOptions {
     movement?: number;
@@ -220,8 +222,12 @@ export const EditableText = forwardRef<EditableTextRef, EditableTextProps>(({
                                 autoFocus
                                 extensions={[
                                     EditorView.lineWrapping,
+                                    keyBindings(() => {save(); return true;}, () => {cancel(); return true;}, "plaintext"),
                                 ]}
-                                onChange={(newValue) => setCurrent(newValue)} />
+                                onChange={(newValue) => setCurrent(newValue)}
+                            >
+                                <MarkupToolbar set={save} cancel={cancel} encoding={"plaintext"} />
+                            </CodeMirror>
                             : <Input
                                 type={multiLine ? "textarea" : "text"}
                                 /* eslint-disable-next-line jsx-a11y/no-autofocus */


### PR DESCRIPTION
Also improves the toolbar when the editor gets a bit small, by summarising/collapsing/simplifying the toolbar options a bit when the CodeMirror editor is under 500px wide.