### PR TITLE
Support for manually indexing drop-zones

### DIFF
--- a/src/components/popups/PopupDropZoneInsert.tsx
+++ b/src/components/popups/PopupDropZoneInsert.tsx
@@ -9,15 +9,16 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
 
     const [width, setWidth] = useState<number>();
     const [height, setHeight] = useState<number>();
+    const [index, setIndex] = useState<number>();
     const [valid, setValid] = useState<boolean>(true);
     const [inLatex, setInLatex] = useState<boolean>(false);
 
     const generateAndInsertDropZone = useCallback(() => {
-        const dropZoneSyntax = `[drop-zone${(width || height) ? "|" : ""}${width ? `w-${width}` : ""}${height ? `h-${height}` : ""}]`;
+        const dropZoneSyntax = `[drop-zone${(width || height || index) ? "|" : ""}${index ? `i-${index}` : ""}${width ? `w-${width}` : ""}${height ? `h-${height}` : ""}]`;
         codemirror.current?.view?.dispatch(
             codemirror.current?.view?.state.replaceSelection(inLatex ? `\\text{${dropZoneSyntax}}` : dropZoneSyntax)
         );
-    }, [width, height, inLatex, codemirror]);
+    }, [width, height, index, inLatex, codemirror]);
 
     const ifValidNumericalInputThen = (f: (n: number | undefined) => void) => (e: React.ChangeEvent<HTMLInputElement>) => {
         const n = parseInt(e.target.value);
@@ -42,6 +43,9 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
                 <Label for={"drop-zone-height"}>Height:</Label>
                 <Input id={"drop-zone-height"} placeholder={"Default"} onChange={ifValidNumericalInputThen(setHeight)} />
                 <hr/>
+                <Label for={"drop-zone-index"}>Index override:</Label>
+                <Input id={"drop-zone-index"} placeholder={"None"} onChange={ifValidNumericalInputThen(setIndex)} />
+                <hr/>
                 <InputGroup className={"pl-4"}>
                     <Label for={"drop-zone-in-latex"}>Inside LaTeX?:</Label>
                     <Input type={"checkbox"} id={"drop-zone-in-latex"} onChange={() => setInLatex(b => !b)} checked={inLatex} />
@@ -52,6 +56,7 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
                         generateAndInsertDropZone();
                         setWidth(undefined);
                         setHeight(undefined);
+                        setIndex(undefined);
                         setInLatex(false);
                         close?.();
                     }}>


### PR DESCRIPTION
This adds editor support for [this front-end PR](https://github.com/isaacphysics/isaac-react-app/pull/661) (which explains how the numbering works). 
Drop-zone indices are now displayed in the rendered markup, so debugging drop-zone order should be much easier.