### PR TITLE
Add `altText` input to item presenters

### DIFF
--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -10,7 +10,7 @@ import {
     ParsonsItem
 } from "../../../isaac-data-types";
 
-import {EditableIDProp, EditableValueProp} from "../props/EditableDocProp";
+import {EditableAltTextProp, EditableIDProp, EditableValueProp} from "../props/EditableDocProp";
 import {QuestionFooterPresenter} from "./questionPresenters";
 import {InserterProps} from "./ListChildrenPresenter";
 import {PresenterProps} from "../registry";
@@ -94,14 +94,21 @@ export function ItemQuestionPresenter(props: PresenterProps<IsaacItemQuestion | 
 }
 
 export function ItemPresenter(props: PresenterProps<Item>) {
-    return <Row>
-        <Col xs={3}>
-            <EditableIDProp {...props} />
-        </Col>
-        <Col xs={8}>
-            <EditableValueProp {...props} multiLine />
-        </Col>
-    </Row>;
+    return <div>
+        <Row>
+            <Col xs={3}>
+                <EditableIDProp {...props} />
+            </Col>
+            <Col xs={8}>
+                <EditableValueProp {...props} multiLine />
+            </Col>
+        </Row>
+        <Row>
+            <Col xs={8} className={"offset-3"}>
+                <EditableAltTextProp {...props} multiLine />
+            </Col>
+        </Row>
+    </div>;
 }
 
 function ItemRow({item}: {item: Item}) {

--- a/src/components/semantic/props/EditableDocProp.tsx
+++ b/src/components/semantic/props/EditableDocProp.tsx
@@ -1,4 +1,4 @@
-import { Content } from "../../../isaac-data-types";
+import { Content, Item } from "../../../isaac-data-types";
 import { EditableText, EditableTextProps, EditableTextRef } from "./EditableText";
 import React, { forwardRef } from "react";
 import { KeysWithValsOfType } from "../../../utils/types";
@@ -35,3 +35,4 @@ export const EditableIDProp = EditableDocPropFor("id", {block: true});
 export const EditableTitleProp = EditableDocPropFor("title", {format: "latex", block: true});
 export const EditableSubtitleProp = EditableDocPropFor("subtitle", {block: true});
 export const EditableValueProp = EditableDocPropFor("value", {block: true});
+export const EditableAltTextProp = EditableDocPropFor<Item>("altText", {block: true, label: "Accessible alt text"});

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -323,6 +323,7 @@ export interface Image extends Media {
 }
 
 export interface Item extends Content {
+    altText?: string;
 }
 
 export interface ItemChoice extends Choice {


### PR DESCRIPTION
Support for adding alt text to item, related to [this front-end PR](https://github.com/isaacphysics/isaac-react-app/pull/662)