### PR TITLE
Add file tree to the CDN modal allowing file deletion and renaming

### DIFF
--- a/src/components/CDNUploadModal.tsx
+++ b/src/components/CDNUploadModal.tsx
@@ -1,12 +1,24 @@
-import React, {useContext, useEffect, useMemo, useState} from "react";
-import {Button, Row, Modal, ModalBody, ModalFooter, ModalHeader, Col, Alert} from "reactstrap";
+import React, {
+    ContextType,
+    useContext,
+    useEffect,
+    useRef,
+    useState
+} from "react";
+import {Button, Row, Modal, ModalBody, ModalFooter, Col, Alert} from "reactstrap";
 import {AppContext} from "../App";
-import {contentsPath, githubCreate, GitHubRepository} from "../services/github";
-import {components, GroupBase, InputActionMeta, SingleValue} from "react-select";
-import useSWR from "swr";
-import CreatableSelect from "react-select/creatable";
-import {isDefined} from "../utils/types";
+import {
+    githubCreate,
+    githubDelete,
+    githubRename,
+} from "../services/github";
 import {FileUploader} from "react-drag-drop-files";
+import {PopupMenuRef, MenuItem, buildPopupMenu, PopupEntry} from "./popups/PopupMenu";
+import styles from "../styles/editor.module.css";
+import {Files, FilesContext, Selection} from "./FileBrowser";
+import {dirname, ext} from "../utils/strings";
+import {GitHubDirInput} from "./GitHubDirInput";
+import {isDefined} from "../utils/types";
 
 export const defaultCdn = {
     open: false,
@@ -15,98 +27,59 @@ export const defaultCdn = {
     }) as () => void,
 };
 
-interface GitHubOption {
-    type: "dir" | "file",
-    label: string;
-    value: string;
-}
-const AlwaysVisibleInput = (props: any) => <components.Input {...props} isHidden={false} />;
+const renameCDNFile = async (context: ContextType<typeof AppContext>, item: PopupEntry, setSelection?: (selection: Selection) => void) => {
+    let newName = window.prompt("Please type a new name for the file. If no extension is provided, \".json\" will be assumed", item.name);
+    if (newName) {
+        // Don't both renaming a file to it's previous name
+        if (item.path.replace(dirname(item.path) + "/", "") === newName) {
+            return;
+        }
+        // Ensure the file type (extension) stays the same
+        if (ext(newName) !== ext(item.name)) {
+            alert("Please don't modify the file extension! Cancelling rename operation...");
+        }
+        const basePath = dirname(item.path);
+        try {
+            await githubRename(context, item.path, newName, "cdn");
+            window.alert("File successfully renamed!");
+            setSelection?.({path: `${basePath}/${newName}`, isDir: false, forceRefresh: true});
+            item.refresh?.();
+        } catch (e) {
+            window.alert("Could not rename file. Perhaps one with that name already exists (see console for error message)");
+            console.log(e);
+        }
+    }
+};
 
-interface GitHubDirInputProps {
-    repo: GitHubRepository;
-    className: string;
-    dir: string | undefined;
-    setDir: (newDir: string | undefined) => void;
-    invalid?: boolean;
-}
-const GitHubDirInput = ({repo, className, dir, setDir, invalid}: GitHubDirInputProps) => {
+const deleteCDNFile = async (context: ContextType<typeof AppContext>, item: PopupEntry, selectionPath?: string, setSelection?: (selection: Selection) => void) => {
+    if (window.confirm("Do you really want to delete " + item.name + "?")) {
+        try {
+            await githubDelete(context, item.path, item.name, item.sha, "cdn");
+            if (selectionPath === item.path) {
+                setSelection?.({path: dirname(item.path), isDir: true});
+                item.refresh?.();
+            }
+            window.alert("File successfully deleted!");
+        } catch (e) {
+            window.alert("Could not delete file (see console for error message)");
+            console.log(e);
+        }
+    }
+};
 
-    // Hacking react-select to do sensible things reading list:
-    //  - https://github.com/JedWatson/react-select/issues/1558#issuecomment-738880505
-    //  - https://github.com/JedWatson/react-select/discussions/4302
-    //  - https://stackoverflow.com/questions/51951379/how-do-i-implement-field-validation-for-react-select
-
+const CDNPopupMenuInner = ({item}: {item: PopupEntry}) => {
     const appContext = useContext(AppContext);
-    const [pathOption, setPathOption] = useState<GitHubOption | null>();
-    const searchablePathPart = dir ? dir.split("/").length === 0 ? dir : dir.split("/").slice(0, -1).join("/") : "";
+    const {selectionPath, setSelection} = useContext(FilesContext);
+    return <>
+        {item?.type === "file" && <MenuItem onClick={() => renameCDNFile(appContext, item, setSelection)} text="Rename..."/>}
+        {item?.type === "file" && <MenuItem onClick={() => deleteCDNFile(appContext, item, selectionPath, setSelection)} text="Delete"/>}
+        {item?.type === "dir" && !item.refresh && <MenuItem onClick={() => void 0} text="No context actions"/>}
+        {item.refresh && <MenuItem onClick={() => item.refresh?.()} text="Refresh"/>}
+    </>;
+};
 
-    const {data, isValidating, error} = useSWR(contentsPath(searchablePathPart ?? "", appContext.github.branch, repo));
+const CDNPopupMenu = buildPopupMenu(CDNPopupMenuInner, "CDNPopupMenu");
 
-    const pathOptions: GroupBase<GitHubOption>[] = useMemo(() => {
-        return (error || !data) ? [] : [{
-            options: data?.type === "file" ? {value: data.path, label: data.path, isDisabled: true} : data?.map((d: any) => ({value: d.path, label: d.path, isDisabled: d.type === "file"})) ?? [],
-            label: "Existing directories"
-        }];
-    }, [error, data]);
-
-    const formatCreateLabel = (path: string) => `Create directory "${path.replace(/\/$/, "")}"`;
-
-    const onInputChange = (inputValue: string, { action }: InputActionMeta) => {
-        // onBlur => setInputValue to last selected value
-        if (action === "input-blur") {
-            setDir(pathOption ? pathOption.value : "");
-        }
-        // onInputChange => update inputValue
-        else if (action === "input-change") {
-            setDir(inputValue);
-        }
-    };
-
-    const onChange = (option: SingleValue<GitHubOption>) => {
-        setPathOption(option);
-        setDir(option ? option.value : "");
-    };
-
-    const getBasePath = (path: string) => {
-        return path.replace(/\/[^/]*$/, "");
-    };
-
-    return <CreatableSelect
-        className={className}
-        isLoading={isValidating}
-        value={pathOption}
-        tabSelectsValue
-        onChange={onChange}
-        inputValue={dir}
-        isClearable
-        onInputChange={onInputChange}
-        controlShouldRenderValue={false}
-        components={{
-            Input: AlwaysVisibleInput
-        }}
-        isValidNewOption={(path, value, options ) => {
-            if (path === "") return false;
-            if (path.match(/^[a-zA-Z0-9_\-/]+$/) === null) return false;
-            const pathToSearch = path.replace(/\/$/, "");
-            return !options.find(o => "value" in o ? [o.value, getBasePath(o.value)].includes(pathToSearch) : o.options.find(_o => [_o.value, getBasePath(_o.value)].includes(pathToSearch)))
-        }}
-        styles={{
-            control: (base, state) => ({
-                ...base,
-                // state.isFocused can display different borderColor if you need it
-                borderColor: !invalid ? '#ddd' : 'red',
-                // overwrittes hover style
-                '&:hover': {
-                    borderColor: !invalid ? '#ddd' : 'red'
-                }
-            })
-        }}
-        options={pathOptions}
-        placeholder={"Choose a directory..."}
-        createOptionPosition={"first"}
-        formatCreateLabel={formatCreateLabel}
-    />;
-}
 type FileValidation = {isValid: true, error?: undefined} | {isValid?: undefined, error: string};
 const validateFile: (file: File | undefined) => FileValidation = (file: File | undefined) => {
     if (!file) return {error: "File doesn't exist"};
@@ -116,14 +89,12 @@ const validateFile: (file: File | undefined) => FileValidation = (file: File | u
     if (fileName.match(/^[a-zA-Z0-9_-]+$/) === null) return {error: "File name is invalid: it can only contain alphanumeric characters, dashes and underscores"};
     return {isValid: true};
 };
-
 const validateDir: (dir: string | undefined) => FileValidation = (dir: string | undefined) => {
     if (!isDefined(dir)) return {error: "Please specify a directory"};
     if (dir === "") return {error: "Please do not upload files to the top level directory"};
     if (dir.match(/^[a-zA-Z0-9_\-/]+$/) === null) return {error: "Directory is invalid: directory names can only contain alphanumeric characters, dashes and underscores"};
     return {isValid: true};
 };
-
 const FILE_TYPE_WHITELIST = ["JPG", "PNG", "GIF", "PDF", "CSV", "ODS", "XLSX"];
 
 export const CDNUploadModal = () => {
@@ -131,27 +102,50 @@ export const CDNUploadModal = () => {
     const {cdn: {open, toggle}} = appContext;
 
     const [files, setFiles] = useState<({file: File} & FileValidation)[] | null>(null);
-    const [dir, setDir] = useState<string>();
+    const [dir, setDir] = useState<{ path: string | undefined, isValid: boolean, error?: string }>();
     const [successfulUploads, setSuccessfulUploads] = useState<string[] | undefined>();
 
-    const dirIsValid = validateDir(dir);
+    const menuRef = useRef<PopupMenuRef>(null);
+    const [selection, setSelection] = useState<Selection>();
+
+    const setSelectionAndUpdateDir = (selection: Selection) => {
+        setSelection(selection);
+        if (!selection) setDir(undefined);
+        if (selection?.isDir) {
+            setDir({path: selection.path, isValid: true});
+        }
+    };
+    const setDirAndUpdateSelection = (dir: string | undefined) => {
+        const validation = validateDir(dir);
+        setDir({path: dir, isValid: "isValid" in validation, error: validation.error});
+        if (dir) {
+            setSelection({isDir: true, path: dir});
+        }
+    };
+
+    // By default select the `isaac` subdirectory
+    useEffect(() => {
+        setDirAndUpdateSelection("isaac");
+    }, []);
+
     const allFilesAreValid = files?.every(f => f.isValid);
-    const paths = dir && dirIsValid.isValid && files ? [...files].map((f) => dir.replace(/\/$/, "") + "/" + f.file.name) : [];
+    const paths = dir?.path && dir.isValid && files ? [...files].map((f) => dir?.path?.replace(/\/$/, "") + "/" + f.file.name) : [];
 
     useEffect(() => {
         if (files && files.length === 0) setSuccessfulUploads(undefined);
     }, [paths, files, dir]);
 
     const uploadToCDN = async () => {
-        if (!files || files.length === 0 || !dir) return;
+        const path = dir?.path;
+        if (!files || files.length === 0 || !path) return;
         const filesToUpload = [...files];
         setFiles(null);
         for (const f of filesToUpload) {
             const reader = new FileReader();
             reader.onload = async () => {
                 try {
-                    await githubCreate(appContext, dir, f.file.name, reader.result as string, "cdn");
-                    setSuccessfulUploads(su => [...(su ?? []), dir.replace(/\/$/, "") + "/" + f.file.name]);
+                    await githubCreate(appContext, path, f.file.name, reader.result as string, "cdn");
+                    setSuccessfulUploads(su => [...(su ?? []), path?.replace(/\/$/, "") + "/" + f.file.name]);
                 } catch (e) {
                     alert(`Couldn't upload file "${f.file.name}" to CDN. Perhaps it already exists.`);
                     console.error(`Couldn't upload file "${f.file.name}" to CDN. Perhaps it already exists.`, e);
@@ -159,17 +153,26 @@ export const CDNUploadModal = () => {
             }
             reader.readAsBinaryString(f.file);
         }
-    }
+    };
 
     const [showAccessibilityNotice, setShowAccessibilityNotice] = useState<boolean>(true);
     useEffect(() => {
         if (open) setShowAccessibilityNotice(true);
     }, [open]);
 
-    return <Modal isOpen={open} toggle={toggle}>
-        <ModalHeader>
-            Upload to CDN
-        </ModalHeader>
+    return <Modal isOpen={open} toggle={toggle} size={"xl"} keyboard={false} backdrop={"static"}>
+        <div className={"modal-header w-100 d-block"}>
+            <Row className={"justify-content-end"}>
+                <Col xs={9} className={"pt-2 pl-4"}>
+                    <h5 className={"modal-title"}>Upload to CDN</h5>
+                </Col>
+                <Col xs={3} className={"pr-4"}>
+                    <Button color={"secondary"} className={"w-100"} onClick={toggle}>
+                        Close
+                    </Button>
+                </Col>
+            </Row>
+        </div>
         <ModalBody>
             {showAccessibilityNotice && <Alert color={"warning"}>
                 <div className={"w-100"}>Accessibility notice<Button color={"none"} className={"float-right mt-n2"} onClick={() => setShowAccessibilityNotice(false)}>✗</Button></div>
@@ -179,61 +182,76 @@ export const CDNUploadModal = () => {
                     Consider whether the document could just be a page on the site, or that an accessible alternative exists.
                 </small>
             </Alert>}
-            <FileUploader
-                types={FILE_TYPE_WHITELIST}
-                maxSize={100}
-                fileOrFiles={files}
-                multiple
-                handleChange={(files: FileList) => {
-                    setFiles(fs => (fs ?? []).concat([...files].map(f => ({file: f, ...validateFile(f)}))));
-                }}
-                classes={"mb-2"}
-            />
-            {files && files.length > 0
-                ? <>
-                    <ul>
-                        {files.map((f, i) => (
-                            <li key={f.file.name} className={f.isValid ? "text-success" : "text-danger"}>
-                                <span style={{fontFamily: "monospace"}}>{f.file.name}</span> {f.isValid ? "✓" : "✗"} {f.error}
-                                <Button color={"link"} className={"p-0 d-inline"} onClick={() => setFiles(files?.length === 1 ? null : files.filter((_, _i) => i !== _i))}>
-                                    Remove
-                                </Button>
-                            </li>
-                        ))}
-                    </ul>
-                    {allFilesAreValid
+            <Row>
+                <Col xs={6} className={"border-right"}>
+                    <p>Type the directory name...</p>
+                    <GitHubDirInput className={"mb-2"} repo={"cdn"} dir={dir?.path} setDir={setDirAndUpdateSelection}
+                                    invalid={!dir?.isValid && isDefined(dir)}/>
+                    {dir?.error && <small className={"text-danger"}>{dir.error}</small>}
+                    <hr/>
+                    <p>Or choose it from the file browser:</p>
+                    <div className={styles.fileBrowser}>
+                        <FilesContext.Provider value={{selectionPath: selection?.path, setSelection: setSelectionAndUpdateDir, repo: "cdn"}}>
+                            <Files menuRef={menuRef} />
+                            <CDNPopupMenu menuRef={menuRef} />
+                        </FilesContext.Provider>
+                    </div>
+                </Col>
+                <Col xs={6}>
+                    <p>Upload one or more file(s) to add to the chosen directory:</p>
+                    <FileUploader
+                        types={FILE_TYPE_WHITELIST}
+                        maxSize={100}
+                        fileOrFiles={files}
+                        multiple
+                        handleChange={(files: FileList) => {
+                            setFiles(fs => (fs ?? []).concat([...files].map(f => ({file: f, ...validateFile(f)}))));
+                        }}
+                        classes={"mb-2"}
+                    />
+                    {files && files.length > 0
                         ? <>
-                            <GitHubDirInput className={"mb-2"} repo={"cdn"} dir={dir} setDir={setDir}
-                                            invalid={!dirIsValid.isValid && isDefined(dir)}/>
-                            {paths && paths.length > 0 && <div>
-                                <span>File(s) to be created:</span>
-                                <ul>
-                                    {paths.map(path => <li key={path}><code>{path}</code></li>)}
-                                </ul>
-                            </div>}
-                            {!dirIsValid.isValid && <small className={isDefined(dir) ? "text-danger" : ""}>{dirIsValid.error}</small>}
+                            <ul>
+                                {files.map((f, i) => (
+                                    <li key={f.file.name} className={f.isValid ? "text-success" : "text-danger"}>
+                                        <span style={{fontFamily: "monospace"}}>{f.file.name}</span> {f.isValid ? "✓" : "✗"} {f.error}
+                                        <Button color={"link"} className={"p-0 d-inline"} onClick={() => setFiles(files?.length === 1 ? null : files.filter((_, _i) => i !== _i))}>
+                                            Remove
+                                        </Button>
+                                    </li>
+                                ))}
+                            </ul>
+                            {allFilesAreValid
+                                ? <>
+                                    {paths && paths.length > 0 && <div>
+                                        <span>File(s) to be created:</span>
+                                        <ul>
+                                            {paths.map(path => <li key={path}><code>{path}</code></li>)}
+                                        </ul>
+                                    </div>}
+                                </>
+                                : <small className={"text-danger"}>Please remove invalid files before continuing</small>}
                         </>
-                        : <small className={"text-danger"}>Please remove invalid files before continuing</small>}
-                </>
-                : <small>Please choose at least one file</small>
-            }
-            {successfulUploads && <Alert className={"mt-2"} color={"success"}>
-                Successfully uploaded files:
-                <ul>
-                    {successfulUploads.map((s, i) => <li key={i}><code>{s}</code></li>)}
-                </ul>
-                The CDN is refreshed every 10 minutes; please check the <code>#compsci</code> Slack channel for
-                confirmation that these files have been added.
-            </Alert>}
+                        : <small>Please choose at least one file</small>
+                    }
+                    {paths && paths.length > 0 && allFilesAreValid && selection?.isDir &&
+                        <Button color={"success"} className={"w-100"} onClick={uploadToCDN}>
+                            Upload file(s) to CDN
+                        </Button>}
+                    {successfulUploads && <Alert className={"mt-2"} color={"success"}>
+                        Successfully uploaded files:
+                        <ul>
+                            {successfulUploads.map((s, i) => <li key={i}><code>{s}</code></li>)}
+                        </ul>
+                        The CDN is refreshed every 10 minutes; please check the <code>#compsci</code> Slack channel for
+                        confirmation that these files have been added.
+                    </Alert>}
+                </Col>
+            </Row>
         </ModalBody>
         <ModalFooter>
             <Row className={"w-100 justify-content-end"}>
-                {paths && paths.length > 0 && allFilesAreValid && dirIsValid.isValid && <Col xs={8}>
-                    <Button color={"success"} className={"w-100"} onClick={uploadToCDN}>
-                        Upload
-                    </Button>
-                </Col>}
-                <Col xs={4}>
+                <Col xs={3}>
                     <Button color={"secondary"} className={"w-100"} onClick={toggle}>
                         Close
                     </Button>
@@ -241,4 +259,4 @@ export const CDNUploadModal = () => {
             </Row>
         </ModalFooter>
     </Modal>;
-}
+};

--- a/src/components/GitHubDirInput.tsx
+++ b/src/components/GitHubDirInput.tsx
@@ -1,0 +1,99 @@
+import React, {useContext, useMemo, useState} from "react";
+import {contentsPath, GitHubRepository} from "../services/github";
+import {components, GroupBase, InputActionMeta, SingleValue} from "react-select";
+import {AppContext} from "../App";
+import useSWR from "swr";
+import CreatableSelect from "react-select/creatable";
+
+interface GitHubOption {
+    type: "dir" | "file",
+    label: string;
+    value: string;
+}
+const AlwaysVisibleInput = (props: any) => <components.Input {...props} isHidden={false} />;
+
+interface GitHubDirInputProps {
+    repo: GitHubRepository;
+    className: string;
+    dir: string | undefined;
+    setDir: (newDir: string | undefined) => void;
+    invalid?: boolean;
+}
+export const GitHubDirInput = ({repo, className, dir, setDir, invalid}: GitHubDirInputProps) => {
+
+    // Hacking react-select to do sensible things reading list:
+    //  - https://github.com/JedWatson/react-select/issues/1558#issuecomment-738880505
+    //  - https://github.com/JedWatson/react-select/discussions/4302
+    //  - https://stackoverflow.com/questions/51951379/how-do-i-implement-field-validation-for-react-select
+
+    const appContext = useContext(AppContext);
+    const [pathOption, setPathOption] = useState<GitHubOption | null>();
+    const searchablePathPart = dir ? dir.split("/").length === 0 ? dir : dir.split("/").slice(0, -1).join("/") : "";
+
+    const {data, isValidating, error} = useSWR(contentsPath(searchablePathPart ?? "", appContext.github.branch, repo));
+
+    const pathOptions: GroupBase<GitHubOption>[] = useMemo(() => {
+        return (error || !data) ? [] : [{
+            options: data?.type === "file" ? {value: data.path, label: data.path, isDisabled: true} : data?.map((d: any) => ({value: d.path, label: d.path, isDisabled: d.type === "file"})) ?? [],
+            label: "Existing directories"
+        }];
+    }, [error, data]);
+
+    const formatCreateLabel = (path: string) => `Create directory "${path.replace(/\/$/, "")}"`;
+
+    const onInputChange = (inputValue: string, { action }: InputActionMeta) => {
+        // onBlur => setInputValue to last selected value
+        if (action === "input-blur") {
+            setDir(pathOption ? pathOption.value : "");
+        }
+        // onInputChange => update inputValue
+        else if (action === "input-change") {
+            setDir(inputValue);
+        }
+    };
+
+    const onChange = (option: SingleValue<GitHubOption>) => {
+        setPathOption(option);
+        setDir(option ? option.value : "");
+    };
+
+    const getBasePath = (path: string) => {
+        return path.replace(/\/[^/]*$/, "");
+    };
+
+    return <CreatableSelect
+        className={className}
+        isLoading={isValidating}
+        value={pathOption}
+        tabSelectsValue
+        onChange={onChange}
+        inputValue={dir}
+        isClearable
+        onInputChange={onInputChange}
+        controlShouldRenderValue={false}
+        components={{
+            Input: AlwaysVisibleInput
+        }}
+        isValidNewOption={(path, value, options ) => {
+            if (path === "") return false;
+            if (path.match(/^[a-zA-Z0-9_\-/]+$/) === null) return false;
+            const pathToSearch = path.replace(/\/$/, "");
+            return !options.find(o => "value" in o ? [o.value, getBasePath(o.value)].includes(pathToSearch) : o.options.find(_o => [_o.value, getBasePath(_o.value)].includes(pathToSearch)))
+        }}
+        styles={{
+            control: (base, state) => ({
+                ...base,
+                // state.isFocused can display different borderColor if you need it
+                borderColor: !invalid ? '#ddd' : 'red',
+                // overwrittes hover style
+                '&:hover': {
+                    borderColor: !invalid ? '#ddd' : 'red'
+                }
+            })
+        }}
+        options={pathOptions}
+        placeholder={"Choose a directory..."}
+        createOptionPosition={"first"}
+        formatCreateLabel={formatCreateLabel}
+    />;
+}

--- a/src/components/popups/Popup.tsx
+++ b/src/components/popups/Popup.tsx
@@ -65,7 +65,8 @@ export function Popup({ popUpRef, children }: { popUpRef: MutableRefObject<Popup
                 className={styles.popup}
                 style={{
                     top: anchorPoint.y,
-                    left: anchorPoint.x
+                    left: anchorPoint.x,
+                    zIndex: 9999,
                 }}
                 ref={insideRef}
             >

--- a/src/components/popups/PopupMenu.tsx
+++ b/src/components/popups/PopupMenu.tsx
@@ -5,6 +5,7 @@ import React, {
     useRef,
     useState
 } from "react";
+import PropTypes from "prop-types";
 
 import { AppContext } from "../../App";
 
@@ -14,7 +15,7 @@ import styles from "../../styles/editor.module.css";
 import { githubReplaceWithConfig } from "../../services/github";
 import {Popup, PopupCloseContext, PopupRef} from "./Popup";
 
-type PopupEntry = Entry & {
+export type PopupEntry = Entry & {
     refresh?: () => void;
 };
 
@@ -35,7 +36,7 @@ type MenuItemProps =
     }
 ;
 
-function MenuItem({
+export function MenuItem({
                       onClick,
                       href,
                       text
@@ -53,59 +54,68 @@ function MenuItem({
     </li>;
 }
 
+export const buildPopupMenu = (PopupInner: React.FC<{item: PopupEntry}>, displayName?: string) => {
+    const PopupMenu = ({menuRef}: { menuRef: MutableRefObject<PopupMenuRef | null> }) => {
+        const [item, setItem] = useState<PopupEntry>(undefined as unknown as PopupEntry);
+        const popupRef = useRef<PopupRef>(null);
+        useImperativeHandle(menuRef, () => ({
+            open: (event, item) => {
+                setItem(item);
+                popupRef.current?.open(event);
+            }
+        }), [setItem]);
 
-export function PopupMenu({menuRef}: { menuRef: MutableRefObject<PopupMenuRef | null> }) {
-    const [item, setItem] = useState<PopupEntry>(undefined as unknown as PopupEntry);
+        return <Popup popUpRef={popupRef}>
+            <ul className={styles.leftMenuPopupMenu}>
+                <PopupInner item={item}/>
+            </ul>
+        </Popup>;
+    }
+    PopupMenu.displayName = displayName ?? PopupInner.displayName;
+    return PopupMenu;
+};
+
+export const FilesPopupMenuInner = ({item}: {item: PopupEntry}) => {
     const appContext = useContext(AppContext);
-
-    const popupRef = useRef<PopupRef>(null);
-
     const isCurrentFile = item?.path === appContext.selection.getSelection()?.path;
-
-    useImperativeHandle(menuRef, () => ({
-        open: (event, item) => {
-            setItem(item);
-            popupRef.current?.open(event);
-        }
-    }), [setItem]);
-
-    return <Popup popUpRef={popupRef}>
-        <ul className={styles.leftMenuPopupMenu}>
-            {item?.type === "dir" && <MenuItem onClick={() => appContext.dispatch({
-                type: "new",
-                path: item.path
-            })} text="New..." />}
-            <MenuItem onClick={() => appContext.dispatch({
-                type: "openInNewTab",
-                path: item.path
-            })} text="Open in new tab" />
-            {item?.type === "dir" && item.refresh && <>
-                <hr />
-                <MenuItem onClick={() => item.refresh?.()} text="Refresh"/>
-            </>}
-            {item?.type === "file" && isCurrentFile && <MenuItem onClick={() => appContext.dispatch({
-                type: "rename",
-                path: item.path,
-                name: item.name,
-            })} text="Rename..." />}
-            {item?.type === "file" && isCurrentFile && <MenuItem onClick={() => appContext.dispatch({
-                type: "saveAs",
-                path: item.path,
-                name: item.name,
-            })} text="Save as..." />}
-            {item?.type === "file" && <MenuItem onClick={() => appContext.dispatch({
-                type: "delete",
-                path: item.path,
-                name: item.name,
-                sha: item.sha,
-            })} text="Delete" />}
-            {item?.type === "file" && <hr />}
-            {item?.type === "file" && <MenuItem href={
-                `${githubReplaceWithConfig("https://github.com/$OWNER/$REPO/blob")}/${appContext.github.branch}/${item.path}`
-            } text="View on github" />}
-            {item?.type === "file" && <MenuItem href={`${githubReplaceWithConfig("https://github.com/$OWNER/$REPO/issues/new")}?body=${encodeURIComponent(
-                    `Issue found in ${item.path} by ${appContext.github.user.login}.\n\n<Describe issue here>`
+    return <>
+        {item?.type === "dir" && <MenuItem onClick={() => appContext.dispatch({
+            type: "new",
+            path: item.path
+        })} text="New..."/>}
+        <MenuItem onClick={() => appContext.dispatch({
+            type: "openInNewTab",
+            path: item.path
+        })} text="Open in new tab"/>
+        {item?.type === "dir" && item.refresh && <>
+            <hr/>
+            <MenuItem onClick={() => item.refresh?.()} text="Refresh"/>
+        </>}
+        {item?.type === "file" && isCurrentFile && <MenuItem onClick={() => appContext.dispatch({
+            type: "rename",
+            path: item.path,
+            name: item.name,
+        })} text="Rename..."/>}
+        {item?.type === "file" && isCurrentFile && <MenuItem onClick={() => appContext.dispatch({
+            type: "saveAs",
+            path: item.path,
+            name: item.name,
+        })} text="Save as..."/>}
+        {item?.type === "file" && <MenuItem onClick={() => appContext.dispatch({
+            type: "delete",
+            path: item.path,
+            name: item.name,
+            sha: item.sha,
+        })} text="Delete"/>}
+        {item?.type === "file" && <hr/>}
+        {item?.type === "file" && <MenuItem href={
+            `${githubReplaceWithConfig("https://github.com/$OWNER/$REPO/blob")}/${appContext.github.branch}/${item.path}`
+        } text="View on github"/>}
+        {item?.type === "file" && <MenuItem
+            href={`${githubReplaceWithConfig("https://github.com/$OWNER/$REPO/issues/new")}?body=${encodeURIComponent(
+                `Issue found in ${item.path} by ${appContext.github.user.login}.\n\n<Describe issue here>`
             )}`} text="Report issue on github"/>}
-        </ul>
-    </Popup>;
-}
+    </>;
+};
+
+export const PopupMenu = buildPopupMenu(FilesPopupMenuInner, "PopupMenu");

--- a/src/utils/strings.ts
+++ b/src/utils/strings.ts
@@ -16,6 +16,11 @@ export function dirname(path: string | undefined) {
     return path.substring(0, path.lastIndexOf('/'));
 }
 
+export function ext(filename: string | undefined): string | undefined {
+    if (!filename) return filename;
+    return filename.indexOf('.') ? filename.substring(filename.indexOf('.')) : undefined;
+}
+
 export function resolveRelativePath(relativeFilename: string, baseSrcPath: string): string {
     return new URL(relativeFilename, "http://example.org/" + baseSrcPath).pathname.substring(1); // The host name is ignored
 }


### PR DESCRIPTION
This makes the CDN upload modal wayyy easier to use and allows content to delete and rename files easily. 

There is still the issue that deletion, renaming and addition of files doesn't update the file tree, but we have some of those problems in the main content file tree already.

I refactored the `Files` and `PopupMenu` components to be a bit more generic; the main thing to check is that this refactor hasn't broken the main content file tree (`FileBrowser`) and it's related right-click popup menu(s).

![image](https://user-images.githubusercontent.com/33040507/212092043-a294484a-7b71-4f65-85fa-312ae2596169.png)