### PR TITLE
Add checkbox option for titled inline glossary terms to content editor

### DIFF
--- a/src/components/popups/PopupGlossaryTermSelect.tsx
+++ b/src/components/popups/PopupGlossaryTermSelect.tsx
@@ -1,4 +1,4 @@
-import React, {ChangeEvent, RefObject, useCallback, useMemo, useRef, useState} from "react";
+import React, {RefObject, useCallback, useMemo, useRef, useState} from "react";
 import {Popup, PopupCloseContext, PopupRef} from "./Popup";
 import {Alert, Button, Container, Input, InputGroup, Label} from "reactstrap";
 import {ReactCodeMirrorRef} from "@uiw/react-codemirror";
@@ -31,15 +31,10 @@ export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, co
     const generateAndInsertGlossaryTerm = useCallback(() => {
         if (glossaryTerm) {
             const trimmedGlossaryTermText = glossaryTermText?.trim();
-            codemirror.current?.view?.dispatch(codemirror.current?.view?.state.replaceSelection(`[glossary${isInlineTerm ? "-inline" : ""}${isTitledTerm ? "-titled" : ""}:${glossaryTerm.value}${isInlineTerm && trimmedGlossaryTermText ? ` "${trimmedGlossaryTermText}"` : ""}]`)
+            codemirror.current?.view?.dispatch(codemirror.current?.view?.state.replaceSelection(`[glossary${isInlineTerm ? "-inline" : ""}${isInlineTerm && isTitledTerm ? "-titled" : ""}:${glossaryTerm.value}${isInlineTerm && trimmedGlossaryTermText ? ` "${trimmedGlossaryTermText}"` : ""}]`)
             );
         }
     }, [glossaryTermText, glossaryTerm, isInlineTerm, codemirror]);
-
-    const onInlineChange = (e: ChangeEvent<HTMLInputElement>) => {
-        setIsInlineTerm(e.target.checked);
-        setIsTitledTerm(e.target.checked && isTitledTerm);
-    }
 
     return <>
         <button className={styles.cmPanelButton} title={"Insert glossary term"} onClick={(event) => {
@@ -55,7 +50,7 @@ export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, co
                 <hr/>
                 <InputGroup className={"pl-4"}>
                     <Label for={"glossary-term-full-or-inline"}>Inline glossary term?</Label>
-                    <Input type={"checkbox"} id="glossary-term-full-or-inline" onChange={e => onInlineChange(e)} checked={isInlineTerm}/>
+                    <Input type={"checkbox"} id="glossary-term-full-or-inline" onChange={e => setIsInlineTerm(e.target.checked)} checked={isInlineTerm}/>
                 </InputGroup>
                 {isInlineTerm ?
                     <>

--- a/src/components/popups/PopupGlossaryTermSelect.tsx
+++ b/src/components/popups/PopupGlossaryTermSelect.tsx
@@ -9,6 +9,7 @@ import {stagingFetcher} from "../../services/isaacApi";
 import Select from "react-select";
 import {Item} from "../../utils/select";
 import {isDefined} from "../../utils/types";
+import { isAda } from "../../services/site";
 
 export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, codemirror: RefObject<ReactCodeMirrorRef> }) => {
     const popupRef = useRef<PopupRef>(null);
@@ -25,12 +26,12 @@ export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, co
     const [glossaryTermText, setGlossaryTermText] = useState<string>();
     const [glossaryTerm, setGlossaryTerm] = useState<Item<string> | undefined>();
     const [isInlineTerm, setIsInlineTerm] = useState<boolean>(true);
+    const [isTitledTerm, setIsTitledTerm] = useState<boolean>(isAda); // Ada should default to being checked
 
     const generateAndInsertGlossaryTerm = useCallback(() => {
         if (glossaryTerm) {
             const trimmedGlossaryTermText = glossaryTermText?.trim();
-            codemirror.current?.view?.dispatch(
-                codemirror.current?.view?.state.replaceSelection(`[glossary${isInlineTerm ? "-inline" : ""}:${glossaryTerm.value}${isInlineTerm && trimmedGlossaryTermText ? ` "${trimmedGlossaryTermText}"` : ""}]`)
+            codemirror.current?.view?.dispatch(codemirror.current?.view?.state.replaceSelection(`[glossary${isInlineTerm ? "-inline" : ""}${isTitledTerm ? "-titled" : ""}:${glossaryTerm.value}${isInlineTerm && trimmedGlossaryTermText ? ` "${trimmedGlossaryTermText}"` : ""}]`)
             );
         }
     }, [glossaryTermText, glossaryTerm, isInlineTerm, codemirror]);
@@ -53,6 +54,10 @@ export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, co
                 </InputGroup>
                 {isInlineTerm ?
                     <>
+                        <InputGroup className={"pl-4"}>
+                            <Label for={"glossary-term-titled-or-not"}>Titled glossary term?</Label>
+                            <Input type={"checkbox"} id="glossary-term-titled-or-not" onChange={e => setIsTitledTerm(e.target.checked)} checked={isTitledTerm}/>
+                        </InputGroup>
                         <Label for={"term-text-input"}>Text to display:</Label>
                         <Input id={"term-text-input"} placeholder={glossaryTerm?.label ?? "None"} value={glossaryTermText} onChange={(e) => setGlossaryTermText(e.target.value)} />
                     </>

--- a/src/components/popups/PopupGlossaryTermSelect.tsx
+++ b/src/components/popups/PopupGlossaryTermSelect.tsx
@@ -1,4 +1,4 @@
-import React, {RefObject, useCallback, useMemo, useRef, useState} from "react";
+import React, {ChangeEvent, RefObject, useCallback, useMemo, useRef, useState} from "react";
 import {Popup, PopupCloseContext, PopupRef} from "./Popup";
 import {Alert, Button, Container, Input, InputGroup, Label} from "reactstrap";
 import {ReactCodeMirrorRef} from "@uiw/react-codemirror";
@@ -36,6 +36,11 @@ export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, co
         }
     }, [glossaryTermText, glossaryTerm, isInlineTerm, codemirror]);
 
+    const onInlineChange = (e: ChangeEvent<HTMLInputElement>) => {
+        setIsInlineTerm(e.target.checked);
+        setIsTitledTerm(e.target.checked && isTitledTerm);
+    }
+
     return <>
         <button className={styles.cmPanelButton} title={"Insert glossary term"} onClick={(event) => {
             popupRef.current?.open(event);
@@ -50,7 +55,7 @@ export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, co
                 <hr/>
                 <InputGroup className={"pl-4"}>
                     <Label for={"glossary-term-full-or-inline"}>Inline glossary term?</Label>
-                    <Input type={"checkbox"} id="glossary-term-full-or-inline" onChange={e => setIsInlineTerm(e.target.checked)} checked={isInlineTerm}/>
+                    <Input type={"checkbox"} id="glossary-term-full-or-inline" onChange={e => onInlineChange(e)} checked={isInlineTerm}/>
                 </InputGroup>
                 {isInlineTerm ?
                     <>


### PR DESCRIPTION
Only glossary inlines can be titled. Ada automatically selects the titled option