### PR TITLE
Add support for stage in glossaryTerms

### DIFF
--- a/src/components/semantic/presenters/GlossaryTermPresenter.tsx
+++ b/src/components/semantic/presenters/GlossaryTermPresenter.tsx
@@ -8,6 +8,8 @@ import styles from "../styles/glossaryTerm.module.css"
 import { SemanticDocProp } from "../props/SemanticDocProp";
 import { EditableIDProp, EditableValueProp } from "../props/EditableDocProp";
 import { TagsPresenter } from "./TagsPresenter";
+import { StagePresenter } from "./StagePresenter";
+import { isPhy } from "../../../services/site";
 
 export function GlossaryTermPresenter(props: PresenterProps<GlossaryTerm>) {
     return <div className={styles.wrapper}>
@@ -15,6 +17,8 @@ export function GlossaryTermPresenter(props: PresenterProps<GlossaryTerm>) {
             <EditableValueProp {...props} placeHolder="Glossary term" block />
             <EditableIDProp {...props} label="Term ID" block />
             <Label>Tags</Label> <TagsPresenter {...props} />
+            {isPhy && <Label>Stage</Label>} 
+            {isPhy && <StagePresenter {...props} />}
         </div>
         <div className={styles.explanation}>
             <SemanticDocProp {...props} prop="explanation" />

--- a/src/components/semantic/presenters/StagePresenter.tsx
+++ b/src/components/semantic/presenters/StagePresenter.tsx
@@ -1,0 +1,65 @@
+import React, { useEffect, useRef, useState } from "react";
+import { Button, Input } from "reactstrap";
+import { GlossaryTerm } from "../../../isaac-data-types";
+
+import { PresenterProps } from "../registry";
+
+import styles from "../styles/tags.module.css";
+
+export function StagePresenter({doc, update}: PresenterProps<GlossaryTerm>) {
+    const [searchString, setSearchString] = useState("");
+    const inputRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+    const [showStageList, setShowStageList] = useState(true);
+    const [filteredStageList, setFilteredStageList] = useState<string[]>();
+
+    useEffect(() => {
+        const stageList: string[] = ["university", "further_a", "a_level", "gcse", "year_9", "year_7_and_8"];
+        setFilteredStageList(stageList?.filter(stage => stage.includes(searchString) && !doc.stages?.includes(stage)));
+    }, [searchString, doc.stages]);
+
+    function addStage(stage: string) {
+        if (doc.stages?.includes(stage)) {
+            return;
+        }
+        update({
+            ...doc,
+            stages: [...doc.stages ?? [], stage],
+        });
+        if (stage === searchString) {
+            setSearchString("");
+            inputRef.current?.focus();
+        }
+    }
+
+    function removeStage(stageToRemove: string) {
+        const stages = doc.stages?.filter(stage => stage !== stageToRemove);
+        update({...doc, stages: stages});
+    }
+
+    function onKeyPress(e: React.KeyboardEvent) {
+        if (e.key === "Enter") {
+            if (filteredStageList?.includes(searchString)) {
+                addStage(searchString);
+            }
+            e.preventDefault();
+        }
+    }
+
+    return <div className={styles.wrapper}>
+        {doc.stages?.map(stage => <Button key={stage} outline onClick={() => removeStage(stage)}>{stage} ➖</Button>)}
+        <Input value={searchString}
+               onChange={(e) => setSearchString(e.target.value.toLowerCase())}
+               placeholder="Type to add stages..."
+               innerRef={inputRef}
+               onKeyPress={onKeyPress}
+        />
+        {searchString !== "" && <div>
+            <Button onClick={() => setShowStageList(!showStageList)}>
+                {showStageList ? "Hide stages" : "Show available stages"}
+            </Button>
+            {showStageList && (filteredStageList?.map((stage) =>
+                <Button key={stage} outline color="primary" onClick={() => addStage(stage)}>{stage} ➕</Button>
+            ) ?? <em>Loading...</em>)}
+        </div>}
+    </div>;
+}

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -328,6 +328,7 @@ export interface FreeTextRule extends Choice {
 export interface GlossaryTerm extends Content {
     explanation?: Content;
     examBoard?: string;
+    stages?: string[];
 }
 
 export interface GraphChoice extends Choice {


### PR DESCRIPTION
Allows physics content editor to add a stage to a new glossary term when created. This functionality is not available on Ada.

Requires https://github.com/isaacphysics/isaac-api/pull/567 and https://github.com/isaacphysics/isaac-react-app/pull/844