### PR TITLE
Add Inline Questions to editor

### DIFF
--- a/src/components/semantic/ChoiceInserter.tsx
+++ b/src/components/semantic/ChoiceInserter.tsx
@@ -27,6 +27,7 @@ export type CHOICE_TYPES =
     | "formula"
     | "chemicalFormula"
     | "stringChoice"
+    | "inlineItem$choice"
     | "freeTextRule"
     | "logicFormula"
     | "graphChoice"
@@ -48,7 +49,8 @@ const emptyChoices = [
     {...emptyChoice, type: "regexPattern", matchWholeString: false, caseInsensitive: false, multiLineRegex: true},
     {...emptyChoice, type: "itemChoice", children: []},
     {...emptyChoice, type: "parsonsChoice", children: []},
-    {...emptyChoice, type: "coordinateChoice", items: []}
+    {...emptyChoice, type: "coordinateChoice", items: []},
+    {...emptyChoice, type: "inlineItem$choice"},
 ];
 
 export const CHOICE_INSERTER_MAP: Partial<Record<ContentType, FunctionComponent<InserterProps>>> = Object.fromEntries(emptyChoices.map((choice) => {

--- a/src/components/semantic/Inserter.tsx
+++ b/src/components/semantic/Inserter.tsx
@@ -35,6 +35,7 @@ const blockTypes = {
     "side-by-side layout": {type: "content", layout: "horizontal", encoding: "markdown", children: []},
     "clearfix": {type: "content", layout: "clearfix", encoding: "markdown", value: ""},
     "callout": {type: "content", layout: "callout", encoding: "markdown", value: "", subtitle: "regular"},
+    "inline region": {type: "isaacInlineRegion", encoding: "markdown", id: generate, children: []},
     "card deck": {type: "isaacCardDeck", encoding: "markdown", value: ""},
     "code snippet": {
         type: "codeSnippet",

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -9,6 +9,7 @@ import {
     Formula,
     FreeTextRule,
     GraphChoice,
+    InlineChoice,
     IsaacNumericQuestion,
     ParsonsChoice,
     Quantity,
@@ -275,6 +276,12 @@ export const CoordinateChoicePresenter = (props: ValuePresenterProps<CoordinateC
     </>;
 }
 
+export const InlineChoicePresenter = (props: ValuePresenterProps<InlineChoice>) => {
+    return <>
+        <ListPresenterProp {...props} prop="items" childTypeOverride="inlineItem$choice" />
+    </>;
+}
+
 const CHOICE_REGISTRY: Record<CHOICE_TYPES, ValuePresenter<Choice>> = {
     choice: BaseValuePresenter,
     quantity: QuantityPresenter,
@@ -282,6 +289,7 @@ const CHOICE_REGISTRY: Record<CHOICE_TYPES, ValuePresenter<Choice>> = {
     chemicalFormula: ChemicalFormulaPresenter,
     stringChoice: StringChoicePresenter,
     freeTextRule: FreeTextRulePresenter,
+    inlineItem$choice: InlineChoicePresenter,
     logicFormula: FormulaPresenter,
     graphChoice: GraphChoicePresenter,
     regexPattern: RegexPatternPresenter,

--- a/src/components/semantic/presenters/ChoicesPresenter.tsx
+++ b/src/components/semantic/presenters/ChoicesPresenter.tsx
@@ -16,6 +16,7 @@ const choicesType: Record<QUESTION_TYPES, CHOICE_TYPES | null> = {
     isaacSymbolicChemistryQuestion: "chemicalFormula",
     isaacStringMatchQuestion: "stringChoice",
     isaacFreeTextQuestion: "freeTextRule",
+    isaacInlineQuestion: "inlineItem$choice",
     isaacSymbolicLogicQuestion: "logicFormula",
     isaacGraphSketcherQuestion: "graphChoice",
     isaacRegexMatchQuestion: "regexPattern",

--- a/src/components/semantic/presenters/ChoicesPresenter.tsx
+++ b/src/components/semantic/presenters/ChoicesPresenter.tsx
@@ -16,7 +16,6 @@ const choicesType: Record<QUESTION_TYPES, CHOICE_TYPES | null> = {
     isaacSymbolicChemistryQuestion: "chemicalFormula",
     isaacStringMatchQuestion: "stringChoice",
     isaacFreeTextQuestion: "freeTextRule",
-    isaacInlineQuestion: "inlineItem$choice",
     isaacSymbolicLogicQuestion: "logicFormula",
     isaacGraphSketcherQuestion: "graphChoice",
     isaacRegexMatchQuestion: "regexPattern",

--- a/src/components/semantic/presenters/InlinePartsPresenter.tsx
+++ b/src/components/semantic/presenters/InlinePartsPresenter.tsx
@@ -6,7 +6,10 @@ import { ListPresenterProp } from "../props/listProps";
 import { Box } from "../SemanticItem";
 
 function Instructions() {
-    return <div className="my-2">Enter the question above, representing any inline question part with <code>[inline-question:id]</code>. Then, add a new inline question part below, setting the question ID to be <code>inline-question:id</code>. These will then link automatically.</div>
+    return <div className="my-2">
+        Enter the question above, representing any inline question part with <code>[inline-question:id]</code>. Then, add a new inline question part below, 
+        setting the question ID to be <code>inline-question:id</code>. These will then link automatically.
+    </div>
 }
 
 export function InlinePartsPresenter(props: PresenterProps<IsaacInlineQuestion>) {

--- a/src/components/semantic/presenters/InlinePartsPresenter.tsx
+++ b/src/components/semantic/presenters/InlinePartsPresenter.tsx
@@ -1,0 +1,21 @@
+import React from "react";
+
+import { IsaacInlineQuestion } from "../../../isaac-data-types";
+import { PresenterProps } from "../registry";
+import { ListPresenterProp } from "../props/listProps";
+import { Box } from "../SemanticItem";
+
+function Instructions() {
+    return <div className="my-2">Enter the question above, representing any inline question part with <code>[inline-question:id]</code>. Then, add a new inline question part below, setting the question ID to be <code>inline-question:id</code>. These will then link automatically.</div>
+}
+
+export function InlinePartsPresenter(props: PresenterProps<IsaacInlineQuestion>) {
+    return <Box name="Inline Parts">
+        <Instructions />
+        <ListPresenterProp {...props}
+                           prop="inlineQuestions"
+                           childTypeOverride="inlineQuestionPart"
+        />
+    </Box>;
+}
+

--- a/src/components/semantic/presenters/InlineQuestionTypePresenter.tsx
+++ b/src/components/semantic/presenters/InlineQuestionTypePresenter.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { EnumPropFor } from "../props/EnumProp";
+import { PresenterProps } from "../registry";
+import { Content } from "../../../isaac-data-types";
+import { changeQuestionType, QUESTION_TYPES } from "./questionPresenters";
+
+export const EditableInlineTypeProp = (props : PresenterProps<Content> & {disabled? : boolean}) => {
+    const {doc, update, disabled} = props;
+
+    const newUpdate : typeof update = (doc) => {
+        update(doc)
+        changeQuestionType({doc, update, newType: doc.type as QUESTION_TYPES});
+    };
+
+    return <div>
+        {EnumPropFor("type", {
+            isaacStringMatchQuestion: "String Match Question", 
+            isaacNumericQuestion: "Numeric Question",
+        })({doc: {...doc, type: doc.type === "inlineQuestionPart" ? "isaacStringMatchQuestion" : doc.type}, 
+            update: newUpdate,
+            dropdownOptions: {disabled: disabled ?? false},
+        })}
+    </div>;
+}

--- a/src/components/semantic/presenters/ListChildrenPresenter.tsx
+++ b/src/components/semantic/presenters/ListChildrenPresenter.tsx
@@ -13,7 +13,7 @@ import {ContentType, PresenterProps} from "../registry";
 import styles from "../styles/semantic.module.css";
 import {ChildTypeOverride} from "../props/listProps";
 import {ItemChoiceItemInserter} from "./ItemQuestionPresenter";
-import {CoordinateChoiceItemInserter} from "./questionPresenters";
+import {CoordinateChoiceItemInserter, InlinePartInserter} from "./questionPresenters";
 
 export interface InserterProps {
     insert: (index: number, newContent: Content) => void;
@@ -61,6 +61,7 @@ const INSERTER_MAP: Partial<Record<ContentType, React.FunctionComponent<Inserter
     item: PlainInserter({type: "item", id: generate, value: ""}),
     parsonsItem: PlainInserter({type: "parsonsItem", id: generate, value: "", indentation: 0}),
     coordinateItem$choice: CoordinateChoiceItemInserter,
+    inlineQuestionPart: InlinePartInserter,
     item$choice: ItemChoiceItemInserter,
 };
 

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -26,7 +26,6 @@ import {ChoicesPresenter} from "./ChoicesPresenter";
 import {InserterProps} from "./ListChildrenPresenter";
 import { ContentValueOrChildrenPresenter } from "./ContentValueOrChildrenPresenter";
 import { InlinePartsPresenter } from "./InlinePartsPresenter";
-import { Box } from "../SemanticItem";
 import { EditableInlineTypeProp } from "./InlineQuestionTypePresenter";
 
 export const QuestionContext = React.createContext<Content | null>(null);
@@ -450,6 +449,7 @@ export function InlineQuestionPartPresenter(props: PresenterProps<IsaacInlinePar
 
     return <>
         <h6><EditableIDProp {...props} label="Question ID"/></h6>
+        {props.doc.id && props.doc.id.match(/^\[|\]$/) && <p className="text-danger"><i>Warning: the ID should not include the surrounding square brackets!</i></p>}
         <EditableInlineTypeProp {...props} disabled={isDisabled} />
         <em>Note: you cannot change the question type if any choices exist.</em>
         {props.doc.type === "isaacNumericQuestion" && <>
@@ -457,6 +457,7 @@ export function InlineQuestionPartPresenter(props: PresenterProps<IsaacInlinePar
             <NumericQuestionPresenter {...props} showMeta={false} />
         </>}
         {choices}
+        <SemanticDocProp {...props} prop="defaultFeedback" name="Default Feedback" />
     </>;
 }
 

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -38,7 +38,6 @@ export type QUESTION_TYPES =
     | "isaacSymbolicChemistryQuestion"
     | "isaacStringMatchQuestion"
     | "isaacFreeTextQuestion"
-    | "isaacInlineQuestion"
     | "isaacSymbolicLogicQuestion"
     | "isaacGraphSketcherQuestion"
     | "isaacRegexMatchQuestion"
@@ -70,9 +69,6 @@ const QuestionTypes: Record<QUESTION_TYPES, {name: string}> = {
     },
     isaacFreeTextQuestion: {
         name: "Free Text Question",
-    },
-    isaacInlineQuestion: {
-        name: "Inline Question",
     },
     isaacSymbolicLogicQuestion: {
         name: "Logic Question",
@@ -449,7 +445,7 @@ export function InlineQuestionPartPresenter(props: PresenterProps<IsaacInlinePar
     </Box>;
 }
 
-export function InlineQuestionPresenter(props: PresenterProps<IsaacInlineQuestion>) {
+export function InlineRegionPresenter(props: PresenterProps<IsaacInlineQuestion>) {
     return <>
         <ContentValueOrChildrenPresenter {...props} />
         <InlinePartsPresenter {...props} />

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -6,6 +6,8 @@ import {
     Content,
     IsaacCoordinateQuestion,
     IsaacGraphSketcherQuestion,
+    IsaacInlinePart,
+    IsaacInlineQuestion,
     IsaacMultiChoiceQuestion,
     IsaacNumericQuestion,
     IsaacQuestionBase,
@@ -22,6 +24,9 @@ import {SemanticListProp} from "../props/listProps";
 import {NumberDocPropFor} from "../props/NumberDocPropFor";
 import {ChoicesPresenter} from "./ChoicesPresenter";
 import {InserterProps} from "./ListChildrenPresenter";
+import { ContentValueOrChildrenPresenter } from "./ContentValueOrChildrenPresenter";
+import { InlinePartsPresenter } from "./InlinePartsPresenter";
+import { Box } from "../SemanticItem";
 
 export const QuestionContext = React.createContext<Content | null>(null);
 
@@ -33,6 +38,7 @@ export type QUESTION_TYPES =
     | "isaacSymbolicChemistryQuestion"
     | "isaacStringMatchQuestion"
     | "isaacFreeTextQuestion"
+    | "isaacInlineQuestion"
     | "isaacSymbolicLogicQuestion"
     | "isaacGraphSketcherQuestion"
     | "isaacRegexMatchQuestion"
@@ -64,6 +70,9 @@ const QuestionTypes: Record<QUESTION_TYPES, {name: string}> = {
     },
     isaacFreeTextQuestion: {
         name: "Free Text Question",
+    },
+    isaacInlineQuestion: {
+        name: "Inline Question",
     },
     isaacSymbolicLogicQuestion: {
         name: "Logic Question",
@@ -196,6 +205,10 @@ export function QuestionFooterPresenter(props: PresenterProps<IsaacQuestionBase>
     </>;
 }
 
+export function HintsPresenter(props: PresenterProps<IsaacQuestionBase>) {
+    return <SemanticListProp {...props} prop="hints" type="hints" />;
+}
+
 export function MultipleChoiceQuestionPresenter(props: PresenterProps) {
     const {doc, update} = props;
     const question = doc as IsaacMultiChoiceQuestion;
@@ -311,6 +324,15 @@ export function CoordinateChoiceItemInserter({insert, position, lengthOfCollecti
     }}>Add</Button>;
 }
 
+export function InlinePartInserter({insert, position, lengthOfCollection}: InserterProps) {
+    if (position !== lengthOfCollection) {
+        return null; // Only include an insert button at the end.
+    }
+    return <Button className={styles.itemsChoiceInserter} color="primary" onClick={() => {
+        insert(position, {type: "inlineQuestionPart"});
+    }}>Add new inline question part</Button>;
+}
+
 export function GraphSketcherQuestionPresenter(props: PresenterProps<IsaacGraphSketcherQuestion>) {
     const {doc, update} = props;
     const question = doc as IsaacCoordinateQuestion;
@@ -415,6 +437,22 @@ export function StringMatchQuestionPresenter(props: PresenterProps<IsaacStringMa
     return <>
         <QuestionMetaPresenter {...props} />
         <CheckboxDocProp {...props} prop="multiLineEntry" label="Multi-line" />
+    </>;
+}
+
+export function InlineQuestionPartPresenter(props: PresenterProps<IsaacInlinePart>) {
+    const {doc} = props;
+    return <Box name="Inline Question Part">
+        <h6><EditableIDProp {...props} label="Question ID"/></h6>
+        {/* TODO: experiment with generifying/genericising/generalising the below */}
+        <ChoicesPresenter {...props} doc={{...doc, type: "isaacStringMatchQuestion"}} />
+    </Box>;
+}
+
+export function InlineQuestionPresenter(props: PresenterProps<IsaacInlineQuestion>) {
+    return <>
+        <ContentValueOrChildrenPresenter {...props} />
+        <InlinePartsPresenter {...props} />
     </>;
 }
 

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -438,11 +438,11 @@ export function StringMatchQuestionPresenter(props: PresenterProps<IsaacStringMa
 
 export function InlineQuestionPartPresenter(props: PresenterProps<IsaacInlinePart>) {
     const {doc} = props;
-    return <Box name="Inline Question Part">
+    return <>
         <h6><EditableIDProp {...props} label="Question ID"/></h6>
         {/* TODO: experiment with generifying/genericising/generalising the below */}
         <ChoicesPresenter {...props} doc={{...doc, type: "isaacStringMatchQuestion"}} />
-    </Box>;
+    </>;
 }
 
 export function InlineRegionPresenter(props: PresenterProps<IsaacInlineQuestion>) {

--- a/src/components/semantic/props/EnumProp.tsx
+++ b/src/components/semantic/props/EnumProp.tsx
@@ -1,18 +1,28 @@
 import {Content} from "../../../isaac-data-types";
 import {KeysWithValsOfType} from "../../../utils/types";
 import {PresenterProps} from "../registry";
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {Dropdown, DropdownItem, DropdownMenu, DropdownToggle} from "reactstrap";
+
+export interface DropdownOptionsProps {
+    disabled?: boolean;
+}
 
 // FIXME the types aren't *quite* right...
 export const EnumPropFor = <
     D extends Content,
     K extends KeysWithValsOfType<D, string | undefined> = KeysWithValsOfType<D, string | undefined>,
     >(prop: K, options: {[key in string]: string | undefined}) => {
-    return function EnumProp({doc, update}: PresenterProps<D>) {
+    return function EnumProp({doc, update, dropdownOptions}: PresenterProps<D> & {dropdownOptions?: DropdownOptionsProps}) {
         const [isOpen, setOpen] = useState(false);
         const current = options[doc[prop] as unknown as keyof typeof options];
-        return <Dropdown toggle={() => setOpen(toggle => !toggle)} isOpen={isOpen}>
+        const disabled = !!(dropdownOptions?.disabled as boolean | undefined);
+
+        useEffect(() => {
+            update(doc);
+        }, []);
+
+        return <Dropdown toggle={() => setOpen(toggle => !toggle)} isOpen={isOpen} disabled={disabled}>
             <DropdownToggle caret>
                 {current ?? "-"}
             </DropdownToggle>

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -76,10 +76,10 @@ export type ContentType =
     | "item"
     | "parsonsItem"
     | "item$choice"
-    | "inlineQuestionPart"
     | "inlineItem$choice"
-    | "coordinateItem$choice"
+    | "inlineQuestionPart"
     | "isaacInlineRegion"
+    | "coordinateItem$choice"
     | QUESTION_TYPES
     | CHOICE_TYPES
 ;
@@ -212,6 +212,15 @@ const isaacCardDeck: RegistryEntry = {
     name: "Card Deck",
     bodyPresenter: CardDeckPresenter,
 };
+const isaacInlineRegion: RegistryEntry = {
+    name: "Inline Region",
+    bodyPresenter: InlineRegionPresenter,
+    footerPresenter: HintsPresenter,
+};
+const isaacInlineQuestionPart: RegistryEntry = {
+    name: "Inline Question Part", 
+    bodyPresenter: InlineQuestionPartPresenter,
+};
 
 const pageMeta: MetaItemKey[] = ["audience", ...defaultMeta, "relatedContent"];
 const pageMetaTail: MetaItemKey[] = ["published", "deprecated"];
@@ -304,8 +313,8 @@ export const REGISTRY: Record<ContentType, RegistryEntry> = {
     freeTextRule: choice,
     isaacRegexMatchQuestion: isaacStringMatchQuestion,
     inlineItem$choice: choice,
-    inlineQuestionPart: {bodyPresenter: InlineQuestionPartPresenter},
-    isaacInlineRegion: {bodyPresenter: InlineRegionPresenter, footerPresenter: HintsPresenter},
+    inlineQuestionPart: isaacInlineQuestionPart,
+    isaacInlineRegion: isaacInlineRegion,
     regexPattern: choice,
     isaacGraphSketcherQuestion: {...question, headerPresenter: GraphSketcherQuestionPresenter},
     graphChoice: choice,

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -4,7 +4,7 @@ import {
     GraphSketcherQuestionPresenter,
     HintsPresenter,
     InlineQuestionPartPresenter,
-    InlineQuestionPresenter,
+    InlineRegionPresenter,
     MultipleChoiceQuestionPresenter,
     NumericQuestionPresenter,
     QUESTION_TYPES,
@@ -79,6 +79,7 @@ export type ContentType =
     | "inlineQuestionPart"
     | "inlineItem$choice"
     | "coordinateItem$choice"
+    | "isaacInlineRegion"
     | QUESTION_TYPES
     | CHOICE_TYPES
 ;
@@ -304,7 +305,7 @@ export const REGISTRY: Record<ContentType, RegistryEntry> = {
     isaacRegexMatchQuestion: isaacStringMatchQuestion,
     inlineItem$choice: choice,
     inlineQuestionPart: {bodyPresenter: InlineQuestionPartPresenter},
-    isaacInlineQuestion: {...question, bodyPresenter: InlineQuestionPresenter, footerPresenter: HintsPresenter},
+    isaacInlineRegion: {bodyPresenter: InlineRegionPresenter, footerPresenter: HintsPresenter},
     regexPattern: choice,
     isaacGraphSketcherQuestion: {...question, headerPresenter: GraphSketcherQuestionPresenter},
     graphChoice: choice,

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -2,6 +2,9 @@ import {
     AnswerPresenter,
     CoordinateQuestionPresenter,
     GraphSketcherQuestionPresenter,
+    HintsPresenter,
+    InlineQuestionPartPresenter,
+    InlineQuestionPresenter,
     MultipleChoiceQuestionPresenter,
     NumericQuestionPresenter,
     QUESTION_TYPES,
@@ -73,6 +76,8 @@ export type ContentType =
     | "item"
     | "parsonsItem"
     | "item$choice"
+    | "inlineQuestionPart"
+    | "inlineItem$choice"
     | "coordinateItem$choice"
     | QUESTION_TYPES
     | CHOICE_TYPES
@@ -297,6 +302,9 @@ export const REGISTRY: Record<ContentType, RegistryEntry> = {
     isaacFreeTextQuestion: isaacStringMatchQuestion,
     freeTextRule: choice,
     isaacRegexMatchQuestion: isaacStringMatchQuestion,
+    inlineItem$choice: choice,
+    inlineQuestionPart: {bodyPresenter: InlineQuestionPartPresenter},
+    isaacInlineQuestion: {...question, bodyPresenter: InlineQuestionPresenter, footerPresenter: HintsPresenter},
     regexPattern: choice,
     isaacGraphSketcherQuestion: {...question, headerPresenter: GraphSketcherQuestionPresenter},
     graphChoice: choice,

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -165,6 +165,13 @@ export interface IsaacStringMatchQuestion extends IsaacQuestionBase {
     preserveTrailingWhitespace?: boolean;
 }
 
+export interface IsaacInlineQuestion extends IsaacQuestionBase {
+    inlineQuestions?: IsaacStringMatchQuestion[];
+}
+
+export interface IsaacInlinePart extends IsaacQuestionBase {
+}
+
 export interface IsaacSymbolicChemistryQuestion extends IsaacSymbolicQuestion {
 }
 
@@ -373,6 +380,9 @@ export interface ParsonsChoice extends ItemChoice {
 export interface CoordinateChoice extends ItemChoice {
 }
 
+export interface InlineChoice extends ItemChoice {
+}
+
 export interface ParsonsItem extends Item {
     indentation?: number;
 }
@@ -380,6 +390,8 @@ export interface ParsonsItem extends Item {
 export interface CoordinateItem extends Item {
     x?: string;
     y?: string;
+}
+export interface InlineItem extends Item {
 }
 
 export interface Quantity extends Choice {


### PR DESCRIPTION
Inline questions are generated by first creating an InlineRegion, a new content type (_not_ a question type, as an inline region is by itself not a question but a wrapper for multiple individual questions). The inline region has a content field at the top in which to write the question as normal. To add an inline question, write `[inline-question:{some_id}]` anywhere in the content field; this can be in plaintext, inside tables, etc. It can work inside KaTeX-rendered expressions, however this is not explicitly supported and breaks the KaTeX screenreader text generation so is not advised.

Next, click "Add new inline question part" underneath the content. By setting the ID of this new question part to `inline-question:{some_id}`, this links the content to the question part. Underneath this, the type of inline question may be changed (currently only supports string match and numeric questions). The question itself is set in exactly the same way as the non-inline equivalent. 

Note that default feedback can be set for each question _part_, however hints are specific to the region _as a whole_. 