### PR TITLE
Nullify default feedback value when deleting

### DIFF
--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -190,7 +190,9 @@ export function QuickQuestionPresenter(props: PresenterProps) {
 export function QuestionFooterPresenter(props: PresenterProps<IsaacQuestionBase>) {
     return <>
         <ChoicesPresenter {...props} />
-        <SemanticDocProp {...props} prop="defaultFeedback" name="Default Feedback" />
+        <SemanticDocProp {...props} prop="defaultFeedback" name="Default Feedback" onDelete={() => 
+            props.update({...props.doc, defaultFeedback: undefined})
+        } />
         <AnswerPresenter {...props} />
         <SemanticListProp {...props} prop="hints" type="hints" />
     </>;


### PR DESCRIPTION
When the defalult feedback box is removed, it was previously being set to a content object with an empty children array, thus showing in the editor as a "Please choose a block type" block, rather than the original empty content block.