### PR TITLE
Prevent inline numeric question checkbox resetting

### DIFF
--- a/src/components/semantic/presenters/InlineQuestionTypePresenter.tsx
+++ b/src/components/semantic/presenters/InlineQuestionTypePresenter.tsx
@@ -2,22 +2,16 @@ import React from "react";
 import { EnumPropFor } from "../props/EnumProp";
 import { PresenterProps } from "../registry";
 import { Content } from "../../../isaac-data-types";
-import { changeQuestionType, QUESTION_TYPES } from "./questionPresenters";
 
 export const EditableInlineTypeProp = (props : PresenterProps<Content> & {disabled? : boolean}) => {
     const {doc, update, disabled} = props;
-
-    const newUpdate : typeof update = (doc) => {
-        update(doc)
-        changeQuestionType({doc, update, newType: doc.type as QUESTION_TYPES});
-    };
 
     return <div>
         {EnumPropFor("type", {
             isaacStringMatchQuestion: "String Match Question", 
             isaacNumericQuestion: "Numeric Question",
         })({doc: {...doc, type: doc.type === "inlineQuestionPart" ? "isaacStringMatchQuestion" : doc.type}, 
-            update: newUpdate,
+            update,
             dropdownOptions: {disabled: disabled ?? false},
         })}
     </div>;


### PR DESCRIPTION
This removes the call to `changeQuestionType` that was resetting values in the checkboxes for inline numeric questions. The type of the question was being changed _prior to calling `changeQuestionType`_, meaning the `requireUnits`, `disregardSignificantFigures` and `displayUnit` fields may have been populated already. In the particular case of `requireUnits` _not_ being present but the others being there, running `changeQuestionType` would reset the other fields. This was leading to particularly inconsistent behaviour as this would not happen if `requireUnits` was _present_ irrespective of its value, (c.f. `changeQuestionType`'s definition).