### PR TITLE
Refactor inline question type selection

### DIFF
--- a/src/components/semantic/presenters/InlineQuestionTypePresenter.tsx
+++ b/src/components/semantic/presenters/InlineQuestionTypePresenter.tsx
@@ -1,18 +1,22 @@
-import React from "react";
-import { EnumPropFor } from "../props/EnumProp";
 import { PresenterProps } from "../registry";
 import { Content } from "../../../isaac-data-types";
+import { QUESTION_TYPES, QuestionTypeSelector } from "./questionPresenters";
+
+export type INLINE_TYPES = Extract<QUESTION_TYPES, "isaacStringMatchQuestion" | "isaacNumericQuestion">;
 
 export const EditableInlineTypeProp = (props : PresenterProps<Content> & {disabled? : boolean}) => {
     const {doc, update, disabled} = props;
 
-    return <div>
-        {EnumPropFor("type", {
-            isaacStringMatchQuestion: "String Match Question", 
-            isaacNumericQuestion: "Numeric Question",
-        })({doc: {...doc, type: doc.type === "inlineQuestionPart" ? "isaacStringMatchQuestion" : doc.type}, 
-            update,
-            dropdownOptions: {disabled: disabled ?? false},
-        })}
-    </div>;
+    const inlineQuestionTypes: Record<INLINE_TYPES, { name: string }> = {
+        isaacStringMatchQuestion: { name: "String Match Question" },
+        isaacNumericQuestion: { name: "Numeric Question" },
+    };
+
+    if (doc.type === "inlineQuestionPart") {
+        const newDoc = {...doc, type: doc.type === "inlineQuestionPart" ? "isaacStringMatchQuestion" : doc.type}
+        update(newDoc);
+        return QuestionTypeSelector({doc: newDoc, update, questionTypes: inlineQuestionTypes, disabled});
+    }
+
+    return QuestionTypeSelector({doc, update, questionTypes: inlineQuestionTypes, disabled});
 }

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -149,24 +149,25 @@ export function changeQuestionType({doc, update, newType} : PresenterProps & {ne
     update(newDoc);
 }
 
-function QuestionTypeSelector({doc, update}: PresenterProps) {
+export function QuestionTypeSelector({doc, update, questionTypes = QuestionTypes, disabled = false}
+    : PresenterProps & {questionTypes?: Partial<Record<QUESTION_TYPES, { name: string; }>>, disabled?: boolean}) {
     const [isOpen, setOpen] = useState(false);
 
-    const questionType = QuestionTypes[doc.type as QUESTION_TYPES];
+    const questionType = questionTypes[doc.type as QUESTION_TYPES];
 
-    return <Dropdown toggle={() => setOpen(toggle => !toggle)} isOpen={isOpen}>
+    return <Dropdown toggle={() => setOpen(toggle => !toggle)} isOpen={isOpen} disabled={disabled}>
         <DropdownToggle caret>
-            {questionType.name}
+            {questionType?.name}
         </DropdownToggle>
         <DropdownMenu>
-            {Object.keys(QuestionTypes).map((key) => {
-                const possibleType = QuestionTypes[key as QUESTION_TYPES];
+            {Object.keys(questionTypes).map((key) => {
+                const possibleType = questionTypes[key as QUESTION_TYPES];
                 return <DropdownItem key={key} active={questionType === possibleType} onClick={() => {
                     if (questionType !== possibleType) {
                         changeQuestionType({doc, update, newType: key as QUESTION_TYPES});
                     }
                 }}>
-                    {possibleType.name}
+                    {possibleType?.name}
                 </DropdownItem>;
             })}
         </DropdownMenu>


### PR DESCRIPTION
The backend defaults `requireUnits` to _true_ if it isn't present. This commit rewrites the InlineQuestionTypeSelector to make use of the original QuestionTypeSelector to forcibly provide default values for all required fields.