### PR TITLE
Always define inline `choices` and `inlineQuestions` fields

### DIFF
--- a/src/components/semantic/ChoiceInserter.tsx
+++ b/src/components/semantic/ChoiceInserter.tsx
@@ -27,7 +27,6 @@ export type CHOICE_TYPES =
     | "formula"
     | "chemicalFormula"
     | "stringChoice"
-    | "inlineItem$choice"
     | "freeTextRule"
     | "logicFormula"
     | "graphChoice"
@@ -50,7 +49,6 @@ const emptyChoices = [
     {...emptyChoice, type: "itemChoice", children: []},
     {...emptyChoice, type: "parsonsChoice", children: []},
     {...emptyChoice, type: "coordinateChoice", items: []},
-    {...emptyChoice, type: "inlineItem$choice"},
 ];
 
 export const CHOICE_INSERTER_MAP: Partial<Record<ContentType, FunctionComponent<InserterProps>>> = Object.fromEntries(emptyChoices.map((choice) => {

--- a/src/components/semantic/Inserter.tsx
+++ b/src/components/semantic/Inserter.tsx
@@ -35,7 +35,7 @@ const blockTypes = {
     "side-by-side layout": {type: "content", layout: "horizontal", encoding: "markdown", children: []},
     "clearfix": {type: "content", layout: "clearfix", encoding: "markdown", value: ""},
     "callout": {type: "content", layout: "callout", encoding: "markdown", value: "", subtitle: "regular"},
-    "inline region": {type: "isaacInlineRegion", encoding: "markdown", id: generate, children: []},
+    "inline region": {type: "isaacInlineRegion", encoding: "markdown", id: generate, children: [], inlineQuestions: []},
     "card deck": {type: "isaacCardDeck", encoding: "markdown", value: ""},
     "code snippet": {
         type: "codeSnippet",

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -9,7 +9,6 @@ import {
     Formula,
     FreeTextRule,
     GraphChoice,
-    InlineChoice,
     IsaacNumericQuestion,
     ParsonsChoice,
     Quantity,
@@ -276,12 +275,6 @@ export const CoordinateChoicePresenter = (props: ValuePresenterProps<CoordinateC
     </>;
 }
 
-export const InlineChoicePresenter = (props: ValuePresenterProps<InlineChoice>) => {
-    return <>
-        <ListPresenterProp {...props} prop="items" childTypeOverride="inlineItem$choice" />
-    </>;
-}
-
 const CHOICE_REGISTRY: Record<CHOICE_TYPES, ValuePresenter<Choice>> = {
     choice: BaseValuePresenter,
     quantity: QuantityPresenter,
@@ -289,7 +282,6 @@ const CHOICE_REGISTRY: Record<CHOICE_TYPES, ValuePresenter<Choice>> = {
     chemicalFormula: ChemicalFormulaPresenter,
     stringChoice: StringChoicePresenter,
     freeTextRule: FreeTextRulePresenter,
-    inlineItem$choice: InlineChoicePresenter,
     logicFormula: FormulaPresenter,
     graphChoice: GraphChoicePresenter,
     regexPattern: RegexPatternPresenter,

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -331,7 +331,7 @@ export function InlinePartInserter({insert, position, lengthOfCollection}: Inser
         return null; // Only include an insert button at the end.
     }
     return <Button className={styles.itemsChoiceInserter} color="primary" onClick={() => {
-        insert(position, {type: "inlineQuestionPart"});
+        insert(position, {type: "inlineQuestionPart", choices: []} as IsaacInlineQuestion);
     }}>Add new inline question part</Button>;
 }
 

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -76,7 +76,6 @@ export type ContentType =
     | "item"
     | "parsonsItem"
     | "item$choice"
-    | "inlineItem$choice"
     | "inlineQuestionPart"
     | "isaacInlineRegion"
     | "coordinateItem$choice"
@@ -312,7 +311,6 @@ export const REGISTRY: Record<ContentType, RegistryEntry> = {
     isaacFreeTextQuestion: isaacStringMatchQuestion,
     freeTextRule: choice,
     isaacRegexMatchQuestion: isaacStringMatchQuestion,
-    inlineItem$choice: choice,
     inlineQuestionPart: isaacInlineQuestionPart,
     isaacInlineRegion: isaacInlineRegion,
     regexPattern: choice,

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -380,9 +380,6 @@ export interface ParsonsChoice extends ItemChoice {
 export interface CoordinateChoice extends ItemChoice {
 }
 
-export interface InlineChoice extends ItemChoice {
-}
-
 export interface ParsonsItem extends Item {
     indentation?: number;
 }
@@ -390,8 +387,6 @@ export interface ParsonsItem extends Item {
 export interface CoordinateItem extends Item {
     x?: string;
     y?: string;
-}
-export interface InlineItem extends Item {
 }
 
 export interface Quantity extends Choice {


### PR DESCRIPTION
Prevents null values being passed into the backend for these lists after nulls broke ETL.

Also removes InlineChoices / classes related from the code. These were not being used as inline questions (now) reuse the choice type as defined by the inline type; that is, inline numeric questions use Quantity, inline string match questions use StringChoice, etc. There is no case in which this type is not defined, so there was no case these InlineChoices were being used.