### PR TITLE
Change the default audience for Scotland qualifications

### DIFF
--- a/src/components/semantic/presenters/AudiencePresenter.tsx
+++ b/src/components/semantic/presenters/AudiencePresenter.tsx
@@ -77,8 +77,6 @@ function AudienceContextPresenter({doc, update, possible}: PresenterProps<Audien
             unusedKeysAndFirstOption = unusedKeysAndFirstOption.filter(([k]) => k !== key);
 
             const filteredUnusedOptions = new Set(possible[key]);
-            // Remove used options
-            values.forEach((value) => filteredUnusedOptions.delete(value));
 
             // Restrict Exam Board options by Stage selection if set
             if (isAda && key === "examBoard" && doc.stage && doc.stage.length === 1) {
@@ -87,7 +85,20 @@ function AudienceContextPresenter({doc, update, possible}: PresenterProps<Audien
                         filteredUnusedOptions.delete(value);
                     }
                 });
+
+                // Remove from values as well to prevent illegal combinations
+                values.forEach((value, i) => {
+                    if (!examBoardsForStage(doc).includes(value as ExamBoard)) {
+                        values.splice(i, 1);
+                    }
+                })
+
+                // Select a default value
+                if (values.length < 1) values.push(examBoardsForStage(doc)[0] as never);
             }
+
+            // Remove used options
+            values.forEach((value) => filteredUnusedOptions.delete(value));
 
             return {
                 key,


### PR DESCRIPTION
Filter the selected examboards (rather than just options) based on the
selected stage and select a default examboard if no selected examboards
remain.
