### PR TITLE
Simplify Ada question difficulty setting with dropdown

### DIFF
--- a/src/components/semantic/presenters/AudiencePresenter.tsx
+++ b/src/components/semantic/presenters/AudiencePresenter.tsx
@@ -267,8 +267,7 @@ function DifficultyEditor({doc, update, possible}: PresenterProps<AudienceContex
     }
 
     const key = doc[0].difficulty ? doc[0].difficulty[0] : "";
-    const possibleOptions = possible.difficulty as Difficulty[];
-    const unusedOptions = new Set([...possibleOptions, ""]) as Set<Difficulty | "">;
+    const unusedOptions = new Set([...possible.difficulty as Difficulty[], ""])
     unusedOptions.delete(key);
 
     return <>
@@ -317,7 +316,7 @@ export function AudiencePresenter({doc, update, type}: PresenterProps & {type?: 
         >
             <AudienceEditor doc={editingAudience} update={setEditingAudience} possible={getPossibleFields(type)} />
             {isAda ? <> 
-                <DifficultyEditor doc={editingAudience as AudienceContext[]} update={setEditingAudience} possible={{difficulty: difficulties}}/> 
+                <DifficultyEditor doc={editingAudience} update={setEditingAudience} possible={{difficulty: difficulties}}/> 
                 <br/> 
             </> : null}
             Concise: {conciseAudiences(editingAudience)}

--- a/src/components/semantic/presenters/AudiencePresenter.tsx
+++ b/src/components/semantic/presenters/AudiencePresenter.tsx
@@ -2,14 +2,14 @@ import React, {Fragment, useState} from "react";
 import {Button} from "reactstrap";
 
 import {AudienceContext, Difficulty, ExamBoard, RoleRequirement, Stage} from "../../../isaac-data-types";
-import {isAda} from "../../../services/site";
+import {isAda, siteSpecific} from "../../../services/site";
 import {ExtractRecordArrayValue, isDefined} from "../../../utils/types";
 
 import {PresenterProps} from "../registry";
 import styles from "../styles/audience.module.css";
 
 function adaDifficulty(doc : AudienceContext[]): Difficulty | undefined {
-    return doc[0].difficulty ? doc[0].difficulty[0] : undefined;
+    return  isAda && doc[0].difficulty ? doc[0].difficulty[0] : undefined;
 } 
 
 function defaultAudience(): AudienceContext {
@@ -209,6 +209,7 @@ function safeJoin(list: string[], joiner: string): string {
     if (list.length === 1) {
         return list[0];
     }
+    list = list.filter((item) => (isAda && difficulties.includes(item as Difficulty)) ? false : true);
     return list.map((item) => item.replaceAll(joiner, "").includes(" ") ? `(${item})` : item).join(joiner);
 }
 
@@ -229,6 +230,11 @@ function conciseAudiences(audiences: AudienceContext[] | undefined | null, type?
     if (audiences === undefined || audiences === null) {
         return type === "accordion" ? "All" : "None set";
     }
+
+    if (adaDifficulty(audiences)) {
+        return safeJoin(audiences.map((audience) => conciseAudience(audience)), " or ") + " and " + adaDifficulty(audiences);
+    }
+
     return safeJoin(audiences.map((audience) => conciseAudience(audience)), " or ");
 }
 
@@ -250,7 +256,7 @@ function AudienceEditor({doc, update, possible}: PresenterProps<AudienceContext[
                     update(audience);
                 }}>➖</Button>}
                 {index === doc.length - 1 ? <Button outline size="sm" onClick={() => {
-                    isAda ? update([...doc, defaultAudienceWithDifficulty(doc)]) : update([...doc, defaultAudience()]);
+                    siteSpecific(update([...doc, defaultAudience()]), update([...doc, defaultAudienceWithDifficulty(doc)]))
                 }}>OR ➕</Button> : " OR"}
             </div>;
         })}

--- a/src/components/semantic/presenters/AudiencePresenter.tsx
+++ b/src/components/semantic/presenters/AudiencePresenter.tsx
@@ -23,7 +23,7 @@ type AudienceKey = keyof AudienceContext;
 type AudienceValue = ExtractRecordArrayValue<Required<AudienceContext>>;
 
 const phyStages: Stage[] = ["university", "further_a", "a_level", "gcse", "year_9", "year_7_and_8"];
-const difficulties: Difficulty[] = ["practice_1", "practice_2", "practice_3", "challenge_1", "challenge_2", "challenge_3", ""];
+const difficulties: Difficulty[] = ["practice_1", "practice_2", "practice_3", "challenge_1", "challenge_2", "challenge_3"];
 
 const csStages: Stage[] = ["a_level", "gcse", "scotland_national_5", "scotland_higher", "scotland_advanced_higher", "core", "advanced"];
 const csExamBoards: ExamBoard[] = ["aqa", "ocr", "cie", "edexcel", "eduqas", "wjec", "sqa", "ada"];
@@ -267,7 +267,8 @@ function DifficultyEditor({doc, update, possible}: PresenterProps<AudienceContex
     }
 
     const key = doc[0].difficulty ? doc[0].difficulty[0] : "";
-    const unusedOptions = new Set(possible.difficulty);
+    const possibleOptions = possible.difficulty as Difficulty[];
+    const unusedOptions = new Set([...possibleOptions, ""]) as Set<Difficulty | "">;
     unusedOptions.delete(key);
 
     return <>

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -426,10 +426,6 @@ export interface AudienceContext {
     role?: RoleRequirement[];
 }
 
-export interface AdaAudienceContext extends AudienceContext {
-    difficulty: Difficulty[];
-}
-
 export interface GameFilter {
     subjects?: string[];
     fields?: string[];

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -476,6 +476,6 @@ export type Stage = "year_7_and_8" | "year_9" | "gcse" | "a_level" | "further_a"
 
 export type ExamBoard = "aqa" | "ocr" | "cie" | "edexcel" | "eduqas" | "wjec" | "sqa" | "ada" | "all";
 
-export type Difficulty = "practice_1" | "practice_2" | "practice_3" | "challenge_1" | "challenge_2" | "challenge_3" | "";
+export type Difficulty = "practice_1" | "practice_2" | "practice_3" | "challenge_1" | "challenge_2" | "challenge_3";
 
 export type RoleRequirement = "logged_in" | "teacher";

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -426,6 +426,10 @@ export interface AudienceContext {
     role?: RoleRequirement[];
 }
 
+export interface AdaAudienceContext extends AudienceContext {
+    difficulty: Difficulty[];
+}
+
 export interface GameFilter {
     subjects?: string[];
     fields?: string[];
@@ -476,6 +480,6 @@ export type Stage = "year_7_and_8" | "year_9" | "gcse" | "a_level" | "further_a"
 
 export type ExamBoard = "aqa" | "ocr" | "cie" | "edexcel" | "eduqas" | "wjec" | "sqa" | "ada" | "all";
 
-export type Difficulty = "practice_1" | "practice_2" | "practice_3" | "challenge_1" | "challenge_2" | "challenge_3";
+export type Difficulty = "practice_1" | "practice_2" | "practice_3" | "challenge_1" | "challenge_2" | "challenge_3" | "";
 
 export type RoleRequirement = "logged_in" | "teacher";


### PR DESCRIPTION
Adds an `adaDifficulty` tracker to unify all difficulty contexts across an Audience category.

A blank "null" option is provided to remove all difficulties (needed for **concepts** pages).

We may want to consider keeping `conciseAudience` in the original format to be clear about the JSON file structure, but I think it's better with less redundant information (see [previous commit](https://github.com/isaacphysics/isaac-content-editor/tree/3c49ee74716ed0629c5bfad841866a059b45e934) for the alternative)


