### PR TITLE
Add deprecated flag to tests

### DIFF
--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -264,7 +264,7 @@ const isaacEventPage: RegistryEntry = {
 const isaacQuiz: RegistryEntry = {
     name: "Test",
     bodyPresenter: QuizPagePresenter,
-    metadata: [...defaultMeta, "visibleToStudents", "hiddenFromTeachers", "published", "attribution"],
+    metadata: [...defaultMeta, "visibleToStudents", "hiddenFromTeachers", "published", "deprecated", "attribution"],
 };
 const isaacQuizSection: RegistryEntry = {
     ...content,


### PR DESCRIPTION
Show a deprecated flag in the editor for tests. This supports a frontend change that hides deprecated tests from users.