### PR TITLE
Add option to allow Chemistry molecule permutation

### DIFF
--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -470,6 +470,7 @@ export function SymbolicChemistryQuestionPresenter(props: PresenterProps<IsaacSy
     return <>
         <SymbolicQuestionPresenter {...props} />
         <CheckboxDocProp {...props} prop="isNuclear" label="Nuclear question" />
+        <CheckboxDocProp {...props} prop="allowPermutations" label="Allow molecule permutations" />
     </>;
 }
 

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -176,6 +176,7 @@ export interface IsaacInlinePart extends IsaacQuestionBase {
 
 export interface IsaacSymbolicChemistryQuestion extends IsaacSymbolicQuestion {
     isNuclear?: boolean;
+    allowPermutations?: boolean;
 }
 
 export interface IsaacSymbolicLogicQuestion extends IsaacSymbolicQuestion {


### PR DESCRIPTION
Adds an option to enable the `allowPermutations` flag for Chemistry Questions.

---

Companion PR to [Allow valid permutations of molecules](https://github.com/isaacphysics/chemistry-checker-js/pull/1) for the Chemistry Checker.

(This relies on the new Chemistry Checker, so that should probably be approved and merged in before this is).