### PR TITLE
Unify MathJax macros with React-App

### DIFF
--- a/src/isaac/markup/latexRendering.ts
+++ b/src/isaac/markup/latexRendering.ts
@@ -5,6 +5,7 @@ import katex, { KatexOptions } from "katex";
 import 'katex/dist/contrib/mhchem.mjs';
 import {BooleanNotation, dropZoneRegex, FigureNumberingContext, FigureNumbersById} from "../IsaacTypes";
 import renderA11yString from "../katex-a11y";
+import { isAda } from "../../services/site";
 
 type MathJaxMacro = string|[string, number];
 
@@ -257,7 +258,11 @@ export function katexify(html: string, user: null, booleanNotation : BooleanNota
                 const latexUnEntitied = he.decode(latex);
                 const latexMunged = munge(latexUnEntitied);
                 let macrosToUse;
-                macrosToUse = booleanNotation?.ENG ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
+                if (isAda) {
+                    macrosToUse = booleanNotation?.ENG ? KatexMacrosWithEngineeringBool : KatexMacrosWithMathsBool;
+                } else {
+                    macrosToUse = KatexBaseMacros;
+                }
                 macrosToUse = {...macrosToUse, "\\ref": (context: {consumeArgs: (n: number) => {text: string}[][]}) => {
                         const args = context.consumeArgs(1);
                         const reference = args[0].reverse().map((t: {text: string}) => t.text).join("");


### PR DESCRIPTION
A change was made to the `latexRendering.ts` file on isaac-react-app a while ago to allow for different macros on Ada and Isaac. This brings those changes to the content editor.

Looking at the use of all affected macros, this should only change the rendering of "\neq" in the editor from `¬= `to `≠` (which we want), and this old [Logic Test](https://editor.isaacphysics.org/edit/master/content/beta_pages/logic_test.json) beta page (which I'm sure is fine).