### PR TITLE
Add the codeTabs content item to editor

### DIFF
--- a/src/components/semantic/Inserter.tsx
+++ b/src/components/semantic/Inserter.tsx
@@ -31,7 +31,7 @@ const blockTypes = {
     "image": {type: "image", encoding: "markdown", value: ""},
     "video": {type: "video", encoding: "markdown", src: "https://www.youtube.com/watch?v=<video_id>"},
     "tabs": {type: "content", layout: "tabs", encoding: "markdown", children: []},
-    "codeTabs": {type: "codeTabs", encoding: "markdown", children: []},
+    "code tabs": {type: "codeTabs", encoding: "markdown", children: []},
     "accordion": {type: "content", layout: "accordion", encoding: "markdown", children: []},
     "side-by-side layout": {type: "content", layout: "horizontal", encoding: "markdown", children: []},
     "clearfix": {type: "content", layout: "clearfix", encoding: "markdown", value: ""},

--- a/src/components/semantic/Inserter.tsx
+++ b/src/components/semantic/Inserter.tsx
@@ -31,6 +31,7 @@ const blockTypes = {
     "image": {type: "image", encoding: "markdown", value: ""},
     "video": {type: "video", encoding: "markdown", src: "https://www.youtube.com/watch?v=<video_id>"},
     "tabs": {type: "content", layout: "tabs", encoding: "markdown", children: []},
+    "codeTabs": {type: "codeTabs", encoding: "markdown", children: []},
     "accordion": {type: "content", layout: "accordion", encoding: "markdown", children: []},
     "side-by-side layout": {type: "content", layout: "horizontal", encoding: "markdown", children: []},
     "clearfix": {type: "content", layout: "clearfix", encoding: "markdown", value: ""},

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -65,6 +65,7 @@ export type ContentType =
     | "figure"
     | "codeSnippet"
     | "interactiveCodeSnippet"
+    | "codeTabs"
     | "image"
     | "video"
     | "glossaryTerm"
@@ -194,6 +195,10 @@ const interactiveCodeSnippet: RegistryEntry = {
     name: "Interactive Code Snippet",
     bodyPresenter: InteractiveCodeSnippetPresenter,
 };
+const codeTabs: RegistryEntry = {
+    name: "Code Tabs",
+    bodyPresenter: TabsPresenter,
+}
 const glossaryTerm: RegistryEntry = {
     name: "Glossary term",
     bodyPresenter: GlossaryTermPresenter,
@@ -344,6 +349,7 @@ export const REGISTRY: Record<ContentType, RegistryEntry> = {
     image: {...figure, name: "Image"},
     codeSnippet,
     interactiveCodeSnippet,
+    codeTabs,
     video,
     glossaryTerm,
     emailTemplate,


### PR DESCRIPTION
Adds `codeTabs` as a content type. This functions like `Tabs`, but when there is a `codeSnippet` child a user's preferred default programming language is switched to on page load.

This is mostly just a fancy wrapper for Tabs right now, but there is scope to expand this e.g. Automatically selecting codeSnippet type in the editor dropdown.