### PR TITLE
Add n-dimensional coord Qs

### DIFF
--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -26,7 +26,7 @@ import {
 } from "./BaseValuePresenter";
 import {SemanticDocProp} from "../props/SemanticDocProp";
 import {CheckboxDocProp} from "../props/CheckboxDocProp";
-import {EditableValueProp, EditableXProp, EditableYProp} from "../props/EditableDocProp";
+import {EditableValueProp, EditableCoordProp} from "../props/EditableDocProp";
 import {CHOICE_TYPES} from "../ChoiceInserter";
 import {PresenterProps} from "../registry";
 import {ListPresenterProp} from "../props/listProps";
@@ -254,16 +254,16 @@ export const ItemChoicePresenter = (props: ValuePresenterProps<ParsonsChoice>) =
 }
 
 export function CoordinateItemPresenter(props: PresenterProps<CoordinateItem>) {
-    return <div className={"mb-3"}>
-        <EditableXProp {...props} label={"x"} />
+    const dimensions = useContext(CoordinateQuestionContext).dimensions;
+    return <>{[...Array(dimensions)].map((_, i) =>
+        <div className={"mb-3"} key={i}>
+            <EditableCoordProp {...props} dim={i} label={"Dimension ".concat(i.toString())} />
         <div className={styles.questionLabel} />
-        <EditableYProp {...props} label={"y"} />
-    </div>;
+    </div>)}</>
 }
 
 export const CoordinateChoicePresenter = (props: ValuePresenterProps<CoordinateChoice>) => {
-    const {numberOfCoordinates} = useContext(CoordinateQuestionContext);
-
+    const numberOfCoordinates = useContext(CoordinateQuestionContext).numberOfCoordinates;
     useEffect(() => {
         if (numberOfCoordinates !== undefined && props.doc.items?.length !== numberOfCoordinates) {
             props.update({...props.doc, items: Array(numberOfCoordinates).fill({x: 0, y: 0, type: "coordinateItem"}).map((placeholder, i) => props.doc.items && props.doc.items[i] ? props.doc.items[i] : placeholder)});

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -257,7 +257,7 @@ export function CoordinateItemPresenter(props: PresenterProps<CoordinateItem>) {
     const numberOfDimensions = useContext(CoordinateQuestionContext).numberOfDimensions;
     return <>{[...Array(numberOfDimensions)].map((_, i) =>
         <div className={"mb-3"} key={i}>
-            <EditableCoordProp {...props} dim={i} prop={"values"} label={"Dimension ".concat((i+1).toString())} />
+            <EditableCoordProp {...props} dim={i} prop={"coordinates"} label={"Dimension ".concat((i+1).toString())} />
         <div className={styles.questionLabel} />
     </div>)}</>
 }
@@ -266,7 +266,7 @@ export const CoordinateChoicePresenter = (props: ValuePresenterProps<CoordinateC
     const numberOfCoordinates = useContext(CoordinateQuestionContext).numberOfCoordinates;
     useEffect(() => {
         if (numberOfCoordinates !== undefined && props.doc.items?.length !== numberOfCoordinates) {
-            props.update({...props.doc, items: Array(numberOfCoordinates).fill({values: [], type: "coordinateItem"}).map((placeholder, i) => props.doc.items && props.doc.items[i] ? props.doc.items[i] : placeholder)});
+            props.update({...props.doc, items: Array(numberOfCoordinates).fill({coordinates: [], type: "coordinateItem"}).map((placeholder, i) => props.doc.items && props.doc.items[i] ? props.doc.items[i] : placeholder)});
         }
     }, [numberOfCoordinates]);
 

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -257,7 +257,7 @@ export function CoordinateItemPresenter(props: PresenterProps<CoordinateItem>) {
     const dimensions = useContext(CoordinateQuestionContext).dimensions;
     return <>{[...Array(dimensions)].map((_, i) =>
         <div className={"mb-3"} key={i}>
-            <EditableCoordProp {...props} dim={i} label={"Dimension ".concat((i+1).toString())} />
+            <EditableCoordProp {...props} dim={i} prop={"values"} label={"Dimension ".concat((i+1).toString())} />
         <div className={styles.questionLabel} />
     </div>)}</>
 }

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -266,7 +266,7 @@ export const CoordinateChoicePresenter = (props: ValuePresenterProps<CoordinateC
     const numberOfCoordinates = useContext(CoordinateQuestionContext).numberOfCoordinates;
     useEffect(() => {
         if (numberOfCoordinates !== undefined && props.doc.items?.length !== numberOfCoordinates) {
-            props.update({...props.doc, items: Array(numberOfCoordinates).fill({x: 0, y: 0, type: "coordinateItem"}).map((placeholder, i) => props.doc.items && props.doc.items[i] ? props.doc.items[i] : placeholder)});
+            props.update({...props.doc, items: Array(numberOfCoordinates).fill({values: [], type: "coordinateItem"}).map((placeholder, i) => props.doc.items && props.doc.items[i] ? props.doc.items[i] : placeholder)});
         }
     }, [numberOfCoordinates]);
 

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -257,7 +257,7 @@ export function CoordinateItemPresenter(props: PresenterProps<CoordinateItem>) {
     const dimensions = useContext(CoordinateQuestionContext).dimensions;
     return <>{[...Array(dimensions)].map((_, i) =>
         <div className={"mb-3"} key={i}>
-            <EditableCoordProp {...props} dim={i} label={"Dimension ".concat(i.toString())} />
+            <EditableCoordProp {...props} dim={i} label={"Dimension ".concat((i+1).toString())} />
         <div className={styles.questionLabel} />
     </div>)}</>
 }

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -254,8 +254,8 @@ export const ItemChoicePresenter = (props: ValuePresenterProps<ParsonsChoice>) =
 }
 
 export function CoordinateItemPresenter(props: PresenterProps<CoordinateItem>) {
-    const dimensions = useContext(CoordinateQuestionContext).dimensions;
-    return <>{[...Array(dimensions)].map((_, i) =>
+    const numberOfDimensions = useContext(CoordinateQuestionContext).numberOfDimensions;
+    return <>{[...Array(numberOfDimensions)].map((_, i) =>
         <div className={"mb-3"} key={i}>
             <EditableCoordProp {...props} dim={i} prop={"values"} label={"Dimension ".concat((i+1).toString())} />
         <div className={styles.questionLabel} />

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -1,5 +1,5 @@
 import React, {createContext, useCallback, useContext, useEffect, useState} from "react";
-import {EditableCoordPropPlaceholders, EditableDocPropFor, EditableIDProp, EditableTitleProp} from "../props/EditableDocProp";
+import {EditableCoordProp, EditableDocPropFor, EditableIDProp, EditableTitleProp} from "../props/EditableDocProp";
 import styles from "../styles/question.module.css";
 import {Alert, Button, Dropdown, DropdownItem, DropdownMenu, DropdownToggle,} from "reactstrap";
 import {
@@ -311,7 +311,7 @@ export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinat
                 <div className="col col-lg-5">
                     {[...Array(question.dimensions)].map((_, i) => 
                      <div className={"mb-3"} key={i}>
-                        <EditableCoordPropPlaceholders {...props} key={i} dim={i} label={"Placeholder ".concat((i+1).toString())} />
+                        <EditableCoordProp {...props} key={i} dim={i} prop={"placeholderValues"} label={"Placeholder ".concat((i+1).toString())} />
                     </div>)}
                 </div>
             </div>

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -303,6 +303,7 @@ export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinat
     return <>
         <QuestionMetaPresenter {...props} />
         <EditableNumberOfCoordinates {...props} />
+        <CheckboxDocProp {...props} prop="ordered" label="Require that order of coordinates in choice and answer are the same" />
         <EditableDimensions {...props} />
         <div className={styles.questionLabel}>
             Coordinate labels:<br/>

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -309,16 +309,19 @@ export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinat
             <small><em>This does not accept latex. Please use a unicode equivalent such as Ψ₁.</em></small>
             <div className="row">
                 <div className="col col-lg-5">
-                    {[...Array(question.dimensions)].map((_, i) => <EditableCoordPropPlaceholders {...props} key={i} dim={i} label={"Placeholder ".concat(i.toString())} />)}
+                    {[...Array(question.dimensions)].map((_, i) => 
+                     <div className={"mb-3"} key={i}>
+                        <EditableCoordPropPlaceholders {...props} key={i} dim={i} label={"Placeholder ".concat((i+1).toString())} />
+                    </div>)}
                 </div>
             </div>
-            Significant figures (affects both x and y values):
+            Significant figures (affects all values):
             <div className="row">
                 <div className="col col-lg-5">
-                    <EditableSignificantFiguresMin doc={question} update={update} />
+                    <EditableSignificantFiguresMin {...props} />
                 </div>
                 <div className="col col-lg-5">
-                    <EditableSignificantFiguresMax doc={question} update={update} />
+                    <EditableSignificantFiguresMax {...props} />
                 </div>
             </div>
         </div>

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -153,7 +153,7 @@ export function changeQuestionType({doc, update, newType} : PresenterProps & {ne
 
     if (newType !== "isaacCoordinateQuestion") {
         delete newDoc.numberOfCoordinates;
-        delete newDoc.dimensions;
+        delete newDoc.numberOfDimensions;
     }
 
     update(newDoc);
@@ -290,11 +290,11 @@ export function NumericQuestionPresenter({showMeta = true, ...props}: {showMeta?
     </>;
 }
 
-export const CoordinateQuestionContext = createContext<{numberOfCoordinates?: number, dimensions?: number}>(
+export const CoordinateQuestionContext = createContext<{numberOfCoordinates?: number, numberOfDimensions?: number}>(
     {}
 );
 const EditableNumberOfCoordinates = NumberDocPropFor<IsaacCoordinateQuestion>("numberOfCoordinates", {label: "Number of coordinates", block: true});
-const EditableDimensions = NumberDocPropFor<IsaacCoordinateQuestion>("dimensions", {label: "Dimensions", block: true});
+const EditableDimensions = NumberDocPropFor<IsaacCoordinateQuestion>("numberOfDimensions", {label: "Dimensions", block: true});
 
 export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinateQuestion>) {
     const {doc, update} = props;
@@ -309,7 +309,7 @@ export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinat
             <small><em>This does not accept latex. Please use a unicode equivalent such as Ψ₁.</em></small>
             <div className="row">
                 <div className="col col-lg-5">
-                    {[...Array(question.dimensions)].map((_, i) => 
+                    {[...Array(question.numberOfDimensions)].map((_, i) => 
                      <div className={"mb-3"} key={i}>
                         <EditableCoordProp {...props} dim={i} prop={"placeholderValues"} label={"Placeholder ".concat((i+1).toString())} />
                     </div>)}
@@ -328,7 +328,7 @@ export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinat
         <div className={styles.questionLabel} /> {/* For spacing */}
         <CoordinateQuestionContext.Provider value={{
             numberOfCoordinates: question.numberOfCoordinates,
-            dimensions: question.dimensions
+            numberOfDimensions: question.numberOfDimensions
         }}>
             <QuestionFooterPresenter {...props} />
         </CoordinateQuestionContext.Provider>

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -290,7 +290,7 @@ export function NumericQuestionPresenter({showMeta = true, ...props}: {showMeta?
     </>;
 }
 
-export const CoordinateQuestionContext = createContext<{numberOfCoordinates?: number, dimensions?: number, placeholderValues?: string[]}>(
+export const CoordinateQuestionContext = createContext<{numberOfCoordinates?: number, dimensions?: number}>(
     {}
 );
 const EditableNumberOfCoordinates = NumberDocPropFor<IsaacCoordinateQuestion>("numberOfCoordinates", {label: "Number of coordinates", block: true});
@@ -311,7 +311,7 @@ export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinat
                 <div className="col col-lg-5">
                     {[...Array(question.dimensions)].map((_, i) => 
                      <div className={"mb-3"} key={i}>
-                        <EditableCoordProp {...props} key={i} dim={i} prop={"placeholderValues"} label={"Placeholder ".concat((i+1).toString())} />
+                        <EditableCoordProp {...props} dim={i} prop={"placeholderValues"} label={"Placeholder ".concat((i+1).toString())} />
                     </div>)}
                 </div>
             </div>
@@ -336,7 +336,7 @@ export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinat
 }
 
 export function CoordinateChoiceItemInserter({insert, position, lengthOfCollection}: InserterProps) {
-    const {numberOfCoordinates} = useContext(CoordinateQuestionContext);
+    const numberOfCoordinates = useContext(CoordinateQuestionContext).numberOfCoordinates;
     if (position !== lengthOfCollection) {
         return null; // Only include an insert button at the end.
     }

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -1,5 +1,5 @@
 import React, {createContext, useCallback, useContext, useEffect, useState} from "react";
-import {EditableDocPropFor, EditableIDProp, EditableTitleProp} from "../props/EditableDocProp";
+import {EditableCoordPropPlaceholders, EditableDocPropFor, EditableIDProp, EditableTitleProp} from "../props/EditableDocProp";
 import styles from "../styles/question.module.css";
 import {Alert, Button, Dropdown, DropdownItem, DropdownMenu, DropdownToggle,} from "reactstrap";
 import {
@@ -152,8 +152,8 @@ export function changeQuestionType({doc, update, newType} : PresenterProps & {ne
     }
 
     if (newType !== "isaacCoordinateQuestion") {
-        delete newDoc.ordered;
         delete newDoc.numberOfCoordinates;
+        delete newDoc.dimensions;
     }
 
     update(newDoc);
@@ -290,35 +290,26 @@ export function NumericQuestionPresenter({showMeta = true, ...props}: {showMeta?
     </>;
 }
 
-export const CoordinateQuestionContext = createContext<{numberOfCoordinates?: number}>(
+export const CoordinateQuestionContext = createContext<{numberOfCoordinates?: number, dimensions?: number, placeholderValues?: string[]}>(
     {}
 );
 const EditableNumberOfCoordinates = NumberDocPropFor<IsaacCoordinateQuestion>("numberOfCoordinates", {label: "Number of coordinates", block: true});
+const EditableDimensions = NumberDocPropFor<IsaacCoordinateQuestion>("dimensions", {label: "Dimensions", block: true});
 
 export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinateQuestion>) {
     const {doc, update} = props;
     const question = doc as IsaacCoordinateQuestion;
 
-    const EditableCoordinateLabelX = EditableDocPropFor<IsaacCoordinateQuestion>(
-        "placeholderXValue", {label: "placeholder X Value", block: true, format: "plain"}
-    );
-    const EditableCoordinateLabelY = EditableDocPropFor<IsaacCoordinateQuestion>(
-        "placeholderYValue", {label: "placeholder Y Value", block: true, format: "plain"}
-    );
-
     return <>
         <QuestionMetaPresenter {...props} />
         <EditableNumberOfCoordinates {...props} />
-        <CheckboxDocProp {...props} prop="ordered" label="Require that order of coordinates in choice and answer are the same" />
+        <EditableDimensions {...props} />
         <div className={styles.questionLabel}>
             Coordinate labels:<br/>
             <small><em>This does not accept latex. Please use a unicode equivalent such as Ψ₁.</em></small>
             <div className="row">
                 <div className="col col-lg-5">
-                    <EditableCoordinateLabelX doc={question} update={update} />
-                </div>
-                <div className="col col-lg-5">
-                    <EditableCoordinateLabelY doc={question} update={update} />
+                    {[...Array(question.dimensions)].map((_, i) => <EditableCoordPropPlaceholders {...props} key={i} dim={i} label={"Placeholder ".concat(i.toString())} />)}
                 </div>
             </div>
             Significant figures (affects both x and y values):
@@ -334,6 +325,7 @@ export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinat
         <div className={styles.questionLabel} /> {/* For spacing */}
         <CoordinateQuestionContext.Provider value={{
             numberOfCoordinates: question.numberOfCoordinates,
+            dimensions: question.dimensions
         }}>
             <QuestionFooterPresenter {...props} />
         </CoordinateQuestionContext.Provider>

--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -152,6 +152,7 @@ export function changeQuestionType({doc, update, newType} : PresenterProps & {ne
     }
 
     if (newType !== "isaacCoordinateQuestion") {
+        delete newDoc.ordered;
         delete newDoc.numberOfCoordinates;
         delete newDoc.numberOfDimensions;
     }

--- a/src/components/semantic/props/EditableDocProp.tsx
+++ b/src/components/semantic/props/EditableDocProp.tsx
@@ -1,4 +1,4 @@
-import {Content, CoordinateItem, Item} from "../../../isaac-data-types";
+import {Content, CoordinateItem, IsaacCoordinateQuestion, Item} from "../../../isaac-data-types";
 import { EditableText, EditableTextProps, EditableTextRef } from "./EditableText";
 import React, { forwardRef } from "react";
 import { KeysWithValsOfType } from "../../../utils/types";
@@ -31,10 +31,63 @@ export const EditableDocPropFor = <
     return forwardRef(typedRender);
 };
 
+function arrayWith<T>(array: T[], index: number, value: T): T[] {
+    if (index >= array.length) {
+        array.length = index + 1;
+    }
+    return [...array.slice(0, index), value, ...array.slice(index + 1)];
+}
+
+export const EditableDocPropForCoords = (dimension: number, defaultProps?: CustomTextProps) => {
+    const typedRender = <D extends CoordinateItem>({doc, update, ...rest}: EditableDocProps<D>, ref: React.ForwardedRef<EditableTextRef>) => {
+        return <EditableText
+            onSave={(newText) => {
+                update({
+                    ...doc,
+                    values: arrayWith(doc["values"] ?? new Array<string>(dimension), dimension, newText)
+                });
+            }}
+            /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+            // @ts-ignore
+            text={doc["values"] ? doc["values"][dimension] : ""}
+            {...defaultProps}
+            {...rest}
+            ref={ref} />
+    };
+    return forwardRef(typedRender);
+};
+
+export const EditableDocPropForCoordsPlaceholders = (dimension: number, defaultProps?: CustomTextProps) => {
+    const typedRender = <D extends IsaacCoordinateQuestion>({doc, update, ...rest}: EditableDocProps<D>, ref: React.ForwardedRef<EditableTextRef>) => {
+        return <EditableText
+            onSave={(newText) => {
+                update({
+                    ...doc,
+                    values: arrayWith(doc["placeholderValues"] ?? new Array<string>(dimension), dimension, newText)
+                });
+            }}
+            /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+            // @ts-ignore
+            text={""}
+            {...defaultProps}
+            {...rest}
+            ref={ref} />
+    };
+    return forwardRef(typedRender);
+};
+
 export const EditableIDProp = EditableDocPropFor("id", {block: true});
 export const EditableTitleProp = EditableDocPropFor("title", {format: "latex", block: true});
 export const EditableSubtitleProp = EditableDocPropFor("subtitle", {block: true});
 export const EditableValueProp = EditableDocPropFor("value", {block: true});
 export const EditableAltTextProp = EditableDocPropFor<Item>("altText", {block: true, label: "Accessible alt text"});
-export const EditableXProp = EditableDocPropFor<CoordinateItem>("x");
-export const EditableYProp = EditableDocPropFor<CoordinateItem>("y");
+export const EditableCoordProp = (props: {dim: number} & PresenterProps<CoordinateItem> & CustomTextProps) => {
+    const {dim, ...restProps} = props;
+    const Component = EditableDocPropForCoords(dim);
+    return <Component {...restProps} />;
+};
+export const EditableCoordPropPlaceholders = (props: {dim: number} & PresenterProps<IsaacCoordinateQuestion> & CustomTextProps) => {
+    const {dim, ...restProps} = props;
+    const Component = EditableDocPropForCoordsPlaceholders(dim);
+    return <Component {...restProps} />;
+};

--- a/src/components/semantic/props/EditableDocProp.tsx
+++ b/src/components/semantic/props/EditableDocProp.tsx
@@ -38,40 +38,24 @@ function arrayWith<T>(array: T[], index: number, value: T): T[] {
     return [...array.slice(0, index), value, ...array.slice(index + 1)];
 }
 
-export const EditableDocPropForCoords = (dimension: number, defaultProps?: CustomTextProps) => {
-    const typedRender = <D extends CoordinateItem>({doc, update, ...rest}: EditableDocProps<D>, ref: React.ForwardedRef<EditableTextRef>) => {
+export const EditableDocPropForCoords = (
+    dimension: number, prop: "values" | "placeholderValues", defaultProps?: CustomTextProps) => {
+    const typedRender = <D extends CoordinateItem | IsaacCoordinateQuestion>({doc, update, ...rest }: EditableDocProps<D>, ref: React.ForwardedRef<EditableTextRef>) => {
+        const currentVal = (prop === "values") ? (doc as CoordinateItem)["values"] : (doc as IsaacCoordinateQuestion)["placeholderValues"];
         return <EditableText
-            onSave={(newText) => {
-                update({
-                    ...doc,
-                    values: arrayWith(doc["values"] ?? new Array<string>(dimension), dimension, newText)
-                });
-            }}
-            /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-            // @ts-ignore
-            text={doc["values"] ? (doc["values"][dimension] ?? "") : ""}
-            {...defaultProps}
-            {...rest}
-            ref={ref} />
-    };
-    return forwardRef(typedRender);
-};
-
-export const EditableDocPropForCoordsPlaceholders = (dimension: number, defaultProps?: CustomTextProps) => {
-    const typedRender = <D extends IsaacCoordinateQuestion>({doc, update, ...rest}: EditableDocProps<D>, ref: React.ForwardedRef<EditableTextRef>) => {
-        return <EditableText
-            onSave={(newText) => {
-                update({
-                    ...doc,
-                    placeholderValues: arrayWith(doc["placeholderValues"] ?? new Array<string>(dimension), dimension, newText)
-                });
-            }}
-            /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
-            // @ts-ignore
-            text={doc["placeholderValues"] ? (doc["placeholderValues"][dimension] ?? "") : ""}
-            {...defaultProps}
-            {...rest}
-            ref={ref} />
+                onSave={(newText) => {
+                    update({
+                        ...doc,
+                        [prop]: arrayWith(currentVal ?? new Array<string>(dimension), dimension, newText)
+                    });
+                }}
+                /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
+                // @ts-ignore
+                text={doc[prop] ? (doc[prop][dimension] ?? "") : ""}
+                {...defaultProps}
+                {...rest}
+                ref={ref}
+            />
     };
     return forwardRef(typedRender);
 };
@@ -81,13 +65,8 @@ export const EditableTitleProp = EditableDocPropFor("title", {format: "latex", b
 export const EditableSubtitleProp = EditableDocPropFor("subtitle", {block: true});
 export const EditableValueProp = EditableDocPropFor("value", {block: true});
 export const EditableAltTextProp = EditableDocPropFor<Item>("altText", {block: true, label: "Accessible alt text"});
-export const EditableCoordProp = (props: {dim: number} & PresenterProps<CoordinateItem> & CustomTextProps) => {
-    const {dim, ...restProps} = props;
-    const Component = EditableDocPropForCoords(dim);
-    return <Component {...restProps} />;
-};
-export const EditableCoordPropPlaceholders = (props: {dim: number} & PresenterProps<IsaacCoordinateQuestion> & CustomTextProps) => {
-    const {dim, ...restProps} = props;
-    const Component = EditableDocPropForCoordsPlaceholders(dim);
+export const EditableCoordProp = (props: {dim: number, prop: "values" | "placeholderValues"} & PresenterProps<CoordinateItem> & CustomTextProps) => {
+    const {dim, prop, ...restProps} = props;
+    const Component = EditableDocPropForCoords(dim, prop);
     return <Component {...restProps} />;
 };

--- a/src/components/semantic/props/EditableDocProp.tsx
+++ b/src/components/semantic/props/EditableDocProp.tsx
@@ -46,7 +46,7 @@ export const EditableDocPropForCoords = (
                 onSave={(newText) => {
                     update({
                         ...doc,
-                        [prop]: arrayWith(currentVal ?? new Array<string>(dimension), dimension, newText)
+                        [prop]: arrayWith(currentVal ?? new Array<string>(dimension).fill(""), dimension, newText)
                     });
                 }}
                 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */

--- a/src/components/semantic/props/EditableDocProp.tsx
+++ b/src/components/semantic/props/EditableDocProp.tsx
@@ -31,13 +31,6 @@ export const EditableDocPropFor = <
     return forwardRef(typedRender);
 };
 
-function arrayWith<T>(array: T[], index: number, value: T): T[] {
-    if (index >= array.length) {
-        array.length = index + 1;
-    }
-    return [...array.slice(0, index), value, ...array.slice(index + 1)];
-}
-
 export const EditableDocPropForCoords = (
     dimension: number, prop: "coordinates" | "placeholderValues", defaultProps?: CustomTextProps) => {
     const typedRender = <D extends CoordinateItem | IsaacCoordinateQuestion>({doc, update, ...rest }: EditableDocProps<D>, ref: React.ForwardedRef<EditableTextRef>) => {
@@ -46,7 +39,7 @@ export const EditableDocPropForCoords = (
                 onSave={(newText) => {
                     update({
                         ...doc,
-                        [prop]: arrayWith(currentVal ?? new Array<string>(dimension).fill(""), dimension, newText)
+                        [prop]: (currentVal ?? new Array<string>(dimension)).with(dimension, newText ?? "")
                     });
                 }}
                 /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */

--- a/src/components/semantic/props/EditableDocProp.tsx
+++ b/src/components/semantic/props/EditableDocProp.tsx
@@ -39,9 +39,9 @@ function arrayWith<T>(array: T[], index: number, value: T): T[] {
 }
 
 export const EditableDocPropForCoords = (
-    dimension: number, prop: "values" | "placeholderValues", defaultProps?: CustomTextProps) => {
+    dimension: number, prop: "coordinates" | "placeholderValues", defaultProps?: CustomTextProps) => {
     const typedRender = <D extends CoordinateItem | IsaacCoordinateQuestion>({doc, update, ...rest }: EditableDocProps<D>, ref: React.ForwardedRef<EditableTextRef>) => {
-        const currentVal = (prop === "values") ? (doc as CoordinateItem)["values"] : (doc as IsaacCoordinateQuestion)["placeholderValues"];
+        const currentVal = (prop === "coordinates") ? (doc as CoordinateItem)["coordinates"] : (doc as IsaacCoordinateQuestion)["placeholderValues"];
         return <EditableText
                 onSave={(newText) => {
                     update({
@@ -65,7 +65,7 @@ export const EditableTitleProp = EditableDocPropFor("title", {format: "latex", b
 export const EditableSubtitleProp = EditableDocPropFor("subtitle", {block: true});
 export const EditableValueProp = EditableDocPropFor("value", {block: true});
 export const EditableAltTextProp = EditableDocPropFor<Item>("altText", {block: true, label: "Accessible alt text"});
-export const EditableCoordProp = (props: {dim: number, prop: "values" | "placeholderValues"} & PresenterProps<CoordinateItem> & CustomTextProps) => {
+export const EditableCoordProp = (props: {dim: number, prop: "coordinates" | "placeholderValues"} & PresenterProps<CoordinateItem> & CustomTextProps) => {
     const {dim, prop, ...restProps} = props;
     const Component = EditableDocPropForCoords(dim, prop);
     return <Component {...restProps} />;

--- a/src/components/semantic/props/EditableDocProp.tsx
+++ b/src/components/semantic/props/EditableDocProp.tsx
@@ -49,7 +49,7 @@ export const EditableDocPropForCoords = (dimension: number, defaultProps?: Custo
             }}
             /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
             // @ts-ignore
-            text={doc["values"] ? doc["values"][dimension] : ""}
+            text={doc["values"] ? (doc["values"][dimension] ?? "") : ""}
             {...defaultProps}
             {...rest}
             ref={ref} />
@@ -63,12 +63,12 @@ export const EditableDocPropForCoordsPlaceholders = (dimension: number, defaultP
             onSave={(newText) => {
                 update({
                     ...doc,
-                    values: arrayWith(doc["placeholderValues"] ?? new Array<string>(dimension), dimension, newText)
+                    placeholderValues: arrayWith(doc["placeholderValues"] ?? new Array<string>(dimension), dimension, newText)
                 });
             }}
             /* eslint-disable-next-line @typescript-eslint/ban-ts-comment */
             // @ts-ignore
-            text={""}
+            text={doc["placeholderValues"] ? (doc["placeholderValues"][dimension] ?? "") : ""}
             {...defaultProps}
             {...rest}
             ref={ref} />

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -54,7 +54,6 @@ export interface IsaacClozeQuestion extends IsaacItemQuestion {
 export interface IsaacCoordinateQuestion extends IsaacQuestionBase {
     significantFiguresMin?: number;
     significantFiguresMax?: number;
-    ordered?: boolean;
     numberOfCoordinates?: number;
     dimensions?: number;
     placeholderValues?: string[];

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -55,7 +55,7 @@ export interface IsaacCoordinateQuestion extends IsaacQuestionBase {
     significantFiguresMin?: number;
     significantFiguresMax?: number;
     numberOfCoordinates?: number;
-    dimensions?: number;
+    numberOfDimensions?: number;
     placeholderValues?: string[];
 }
 

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -409,7 +409,7 @@ export interface ParsonsItem extends Item {
 }
 
 export interface CoordinateItem extends Item {
-    values?: string[];
+    coordinates?: string[];
 }
 
 export interface Quantity extends Choice {

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -56,8 +56,8 @@ export interface IsaacCoordinateQuestion extends IsaacQuestionBase {
     significantFiguresMax?: number;
     ordered?: boolean;
     numberOfCoordinates?: number;
-    placeholderXValue?: string;
-    placeholderYValue?: string;
+    dimensions?: number;
+    placeholderValues?: string[];
 }
 
 export interface IsaacConceptPage extends SeguePage {
@@ -412,6 +412,8 @@ export interface ParsonsItem extends Item {
 export interface CoordinateItem extends Item {
     x?: string;
     y?: string;
+    values?: string[];
+    dimensions?: number;
 }
 
 export interface Quantity extends Choice {

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -54,6 +54,7 @@ export interface IsaacClozeQuestion extends IsaacItemQuestion {
 export interface IsaacCoordinateQuestion extends IsaacQuestionBase {
     significantFiguresMin?: number;
     significantFiguresMax?: number;
+    ordered?: boolean;
     numberOfCoordinates?: number;
     numberOfDimensions?: number;
     placeholderValues?: string[];

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -410,10 +410,7 @@ export interface ParsonsItem extends Item {
 }
 
 export interface CoordinateItem extends Item {
-    x?: string;
-    y?: string;
     values?: string[];
-    dimensions?: number;
 }
 
 export interface Quantity extends Choice {


### PR DESCRIPTION
Add support to the content editor for coordinate questions with any number of dimensions.

This adds a 'dimensions' property to coordinate questions and replaces the current inputs for x and y with some number of inputs as determined by the dimensions set for the question (currently unlimited). Values for each choice (and placeholder values for each question) are stored as a list instead of separate x and y properties.