### PR TITLE
Hide "Edited filename.json" on save

### DIFF
--- a/src/services/github.ts
+++ b/src/services/github.ts
@@ -363,12 +363,16 @@ export async function githubSave(context: ContextType<typeof AppContext>) {
         isContent = false;
     }
     const path = context.selection.getSelection()?.path as string;
-    const initialCommitMessage = `${isPublishedChange ? "* " : ""}Edited ${path.split("/").at(-1)}`;
+    const initialCommitMessage = `${isPublishedChange ? "* " : ""}Edited ${path.split("/").at(-1)}: `;
 
-    const message = window.prompt("Enter your commit message", initialCommitMessage);
+    let userMessage = window.prompt("Enter your commit message:");
+    while (userMessage === "") {
+        userMessage = window.prompt("Could not save file with no commit message.\nEnter your commit message:")
+    }
     const {sha} = context.github.cache.get(contentsPath(path, context.github.branch))?.data ?? {};
-    if (!sha || !message) return;
+    if (!sha || !userMessage) return;
 
+    const message = initialCommitMessage + userMessage;
     const encodedContent = encodeContent(context.editor.getCurrentDocAsString(), context.editor.getCurrentDocExt());
 
     const body = {


### PR DESCRIPTION
We want to enforce all content editor commits to have associated commit messages to be easier to review/debug/check for content pushes/etc. 

This achieves that by hiding the `"*? Edited filename.json"` text from the name window (it will still appear in the commit message itself), and failing/asking the user to retry on an empty commit message. Just failing with no message would've been slightly simpler, but seems unclear and I don't want progress to be lost because of it.

(While making this change, it got me thinking that it could eventually be worth considering adding an entirely new modal for functions like giving warnings about empty/long commit messages, allowing use of a description, greying out the enter button when invalid, disabling invalid characters, etc., but it's a relative lot of work and I don't think it's a priority)
