### PR TITLE
Remove visibleToStudents quiz property

### DIFF
--- a/src/components/semantic/metaItems.tsx
+++ b/src/components/semantic/metaItems.tsx
@@ -168,12 +168,11 @@ function VisibleToStudents({doc, update, ...rest}: MetaItemPresenterProps<IsaacQ
         }
         update({
             ...doc,
-            visibleToStudents,
             hiddenFromRoles,
         });
     };
 
-    return <Input type="checkbox" {...rest} checked={!!doc.visibleToStudents} onChange={(e) => onChange(e.target.checked)} />;
+    return <Input type="checkbox" {...rest} checked={!doc.hiddenFromRoles?.includes("STUDENT")} onChange={(e) => onChange(e.target.checked)} />;
 }
 
 function DateTimeInput({doc, update, prop, options, ...rest}: MetaItemPresenterProps<IsaacEventPage>) {
@@ -230,17 +229,14 @@ function DateTimeInput({doc, update, prop, options, ...rest}: MetaItemPresenterP
 
 function HiddenFromTeachers({doc, update, ...rest}: MetaItemPresenterProps<IsaacQuiz>) {
     const onChange = (hiddenFromTeachers: boolean) => {
-        let visibleToStudents = doc.visibleToStudents;
         let hiddenFromRoles = doc.hiddenFromRoles;
         if (hiddenFromTeachers) {
             hiddenFromRoles = [...new Set([...hiddenFromRoles ?? [], "TEACHER", "STUDENT"]).keys()];
-            visibleToStudents = false; // If teachers can't see it, neither can students
         } else {
             hiddenFromRoles = hiddenFromRoles?.filter((role) => role !== "TEACHER");
         }
         update({
             ...doc,
-            visibleToStudents,
             hiddenFromRoles,
         });
     };

--- a/src/components/semantic/metaItems.tsx
+++ b/src/components/semantic/metaItems.tsx
@@ -71,7 +71,7 @@ export const MetaItems = asMetaItems({
     description: "Description",
     url: "URL",
     relatedContent: ["Related content", {presenter: RelatedContentPresenter}],
-    visibleToStudents: ["Visible to students", {presenter: VisibleToStudents}],
+    hiddenFromStudentsAndTutors: ["Hidden from students/tutors", {presenter: HiddenFromStudentsAndTutors}],
     hiddenFromTeachers: ["Hidden from teachers", {presenter: HiddenFromTeachers}],
     linkedGameboards: ["Linked gameboards", {presenter: LinkedGameboardsPresenter}],
 
@@ -157,14 +157,14 @@ function Deprecated({doc, update, ...rest}: MetaItemPresenterProps<Content>) {
 }
 
 
-function VisibleToStudents({doc, update, ...rest}: MetaItemPresenterProps<IsaacQuiz>) {
-    const onChange = (visibleToStudents: boolean) => {
+function HiddenFromStudentsAndTutors({doc, update, ...rest}: MetaItemPresenterProps<IsaacQuiz>) {
+    const onChange = (hiddenFromStudentsAndTutors: boolean) => {
         let hiddenFromRoles = doc.hiddenFromRoles;
-        if (visibleToStudents) {
-            hiddenFromRoles = []; // If students can see it, everyone can see it
+        if (!hiddenFromStudentsAndTutors) {
+            hiddenFromRoles = []; // If they can see it, everyone can!
         } else {
             // Duplicate not visible into the hidden from roles
-            hiddenFromRoles = [...new Set([...hiddenFromRoles ?? [], "STUDENT"]).keys()];
+            hiddenFromRoles = [...new Set([...hiddenFromRoles ?? [], "STUDENT", "TUTOR"]).keys()];
         }
         update({
             ...doc,
@@ -172,7 +172,8 @@ function VisibleToStudents({doc, update, ...rest}: MetaItemPresenterProps<IsaacQ
         });
     };
 
-    return <Input type="checkbox" {...rest} checked={!doc.hiddenFromRoles?.includes("STUDENT")} onChange={(e) => onChange(e.target.checked)} />;
+    const currentlyHidden = doc.hiddenFromRoles?.includes("STUDENT") && doc.hiddenFromRoles?.includes("TUTOR");
+    return <Input type="checkbox" {...rest} checked={currentlyHidden} onChange={(e) => onChange(e.target.checked)} />;
 }
 
 function DateTimeInput({doc, update, prop, options, ...rest}: MetaItemPresenterProps<IsaacEventPage>) {
@@ -231,7 +232,7 @@ function HiddenFromTeachers({doc, update, ...rest}: MetaItemPresenterProps<Isaac
     const onChange = (hiddenFromTeachers: boolean) => {
         let hiddenFromRoles = doc.hiddenFromRoles;
         if (hiddenFromTeachers) {
-            hiddenFromRoles = [...new Set([...hiddenFromRoles ?? [], "TEACHER", "STUDENT"]).keys()];
+            hiddenFromRoles = [...new Set([...hiddenFromRoles ?? [], "TEACHER", "TUTOR", "STUDENT"]).keys()];
         } else {
             hiddenFromRoles = hiddenFromRoles?.filter((role) => role !== "TEACHER");
         }

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -233,7 +233,7 @@ const isaacInlineRegion: RegistryEntry = {
     footerPresenter: HintsPresenter,
 };
 const isaacInlineQuestionPart: RegistryEntry = {
-    name: "Inline Question Part", 
+    name: "Inline Question Part",
     bodyPresenter: InlineQuestionPartPresenter,
 };
 
@@ -275,7 +275,7 @@ const isaacEventPage: RegistryEntry = {
 const isaacQuiz: RegistryEntry = {
     name: "Test",
     bodyPresenter: QuizPagePresenter,
-    metadata: ["audience", ...defaultMeta, "visibleToStudents", "hiddenFromTeachers", "published", "deprecated", "attribution"],
+    metadata: ["audience", ...defaultMeta, "hiddenFromStudentsAndTutors", "hiddenFromTeachers", "published", "deprecated", "attribution"],
 };
 const isaacQuizSection: RegistryEntry = {
     ...content,

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -190,7 +190,6 @@ export interface IsaacQuickQuestion extends IsaacQuestionBase {
 }
 
 export interface IsaacQuiz extends SeguePage {
-    visibleToStudents?: boolean;
     hiddenFromRoles?: string[];
     rubric?: Content;
 }

--- a/src/services/emptyDocuments.ts
+++ b/src/services/emptyDocuments.ts
@@ -67,7 +67,7 @@ const emptyDocuments: Document[] = [
         type: "isaacQuiz",
         encoding: "markdown",
         title: "New Test",
-        hiddenFromRoles: ["STUDENT"],
+        hiddenFromRoles: ["STUDENT", "TUTOR"],
         published: false,
         rubric: {
             type: "content",

--- a/src/services/emptyDocuments.ts
+++ b/src/services/emptyDocuments.ts
@@ -67,7 +67,7 @@ const emptyDocuments: Document[] = [
         type: "isaacQuiz",
         encoding: "markdown",
         title: "New Test",
-        visibleToStudents: false,
+        hiddenFromRoles: ["STUDENT"],
         published: false,
         rubric: {
             type: "content",


### PR DESCRIPTION
The two tickboxes are likely still the best way to interact with the underlying list, though; so there are still references to "visibleToStudents".