### PR TITLE
Add support for teacher notes in fragment & page metadata

### DIFF
--- a/src/components/semantic/metaItems.tsx
+++ b/src/components/semantic/metaItems.tsx
@@ -48,6 +48,7 @@ export const MetaItems = asMetaItems({
     attribution: ["Attribution", {deleteIfEmpty: true}],
     permissions: ["Permissions", {deleteIfEmpty: true}],
     notes: ["Notes", {deleteIfEmpty: true}],
+    teacherNotes: ["Teacher Notes", {type: "textarea", deleteIfEmpty: true}],
     supersededBy: ["Superseded By", {deleteIfEmpty: true}],
     level: ["Level", {type: "number", hasWarning: (value) => {
         const level = value as number; // Already parsed by virtue of type: "number"

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -237,7 +237,7 @@ const isaacInlineQuestionPart: RegistryEntry = {
     bodyPresenter: InlineQuestionPartPresenter,
 };
 
-const pageMeta: MetaItemKey[] = ["audience", ...defaultMeta, "relatedContent", "permissions", "notes"];
+const pageMeta: MetaItemKey[] = ["audience", ...defaultMeta, "relatedContent", "permissions", "notes", "teacherNotes"];
 const pageMetaTail: MetaItemKey[] = ["published", "deprecated"];
 const basePage: RegistryEntry = {
     ...content,


### PR DESCRIPTION
Adds a `teacherNotes` field as a textarea in most page types' metadata. Depending on how content use this, we may switch from a textarea to a markdown-compatible component, and potentially move this out of the metadata; this is only intended as a rough, working implementation to get a feel for how it would be used.

Note that this **should not be pushed without content understanding that adding teacherNotes to content will break it on the live (non-redesign) site**.