### PR TITLE
Add warning for missing maxMarks field

### DIFF
--- a/src/components/semantic/presenters/LLMQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/LLMQuestionPresenter.tsx
@@ -179,7 +179,12 @@ export function LLMQuestionPresenter(props: PresenterProps<IsaacLLMFreeTextQuest
             </tbody>
             <tfoot>
                 <tr>
-                    <td><strong><pre>maxMarks</pre></strong></td>
+                    <td>
+                        <strong><pre>maxMarks</pre></strong>
+                        {doc.maxMarks === undefined && 
+                            <FormFeedback className={styles.feedback}> maxMarks is a required field </FormFeedback>
+                        }
+                    </td>
                     <td><MaxMarksEditor {...props} /></td>
                 </tr>
                 <tr>


### PR DESCRIPTION
Related to https://github.com/isaacphysics/isaac-api/pull/691. It should now be _safe_ to include no maxMarks field, but will mean that students always receive a mark total of 0 so it should still be avoided - hence this warning. 