### PR TITLE
Add support for changing tab styles in editor

### DIFF
--- a/src/components/semantic/presenters/TabsPresenter.tsx
+++ b/src/components/semantic/presenters/TabsPresenter.tsx
@@ -8,7 +8,7 @@ import { useFixedRef } from "../../../utils/hooks";
 
 import { SemanticItem } from "../SemanticItem";
 import { deriveNewDoc } from "./ListChildrenPresenter";
-import { EditableIDProp, EditableTitleProp } from "../props/EditableDocProp";
+import { EditableDocPropWithStyle, EditableIDProp, EditableTitleProp } from "../props/EditableDocProp";
 import { EditableTextRef } from "../props/EditableText";
 import { PresenterProps } from "../registry";
 import styles from "../styles/tabs.module.css";
@@ -33,6 +33,13 @@ export type TabsProps = {
     index: number;
     setIndex: (newIndex: number) => void;
 } & TabsSettings;
+
+const EditableTabsLayoutProp = EditableDocPropWithStyle("layout", [
+    {value: "tabs", label: "Tabs"},
+    {value: "buttons", label: "Buttons"},
+    {value: "dropdowns", label: "Dropdowns"},
+    {value: undefined, label: "Default"}
+], "Tab display type:", {value: "tabs", label: "Tabs"}, {block: true});
 
 export function TabsHeader({docRef, doInsert, index, setIndex, elementName, styles, suppressHeaderNames, showTitles}: TabsProps) {
     const elementNameLC = safeLowercase(elementName);
@@ -185,7 +192,8 @@ export function TabsPresenter(props: TabsPresenterProps) {
     });
 
     return <div className={styles.wrapper}>
-        <TabsHeader {...allProps} />
+        <EditableTabsLayoutProp {...props}/>
+        <TabsHeader {...allProps} {...props} />
         <TabsMain {...allProps} back="◀" forward="▶" contentHeader={
             showTitles && currentChild ? <div className={styles.meta}>
                 <h3><EditableTitleProp ref={editTitleRef} {...currentChildProps}

--- a/src/components/semantic/props/EditableDocProp.tsx
+++ b/src/components/semantic/props/EditableDocProp.tsx
@@ -3,6 +3,9 @@ import { EditableText, EditableTextProps, EditableTextRef } from "./EditableText
 import React, { forwardRef } from "react";
 import { KeysWithValsOfType } from "../../../utils/types";
 import { PresenterProps } from "../registry";
+import Select from "react-select";
+import { Label } from "reactstrap";
+import { generateGuid } from "../../../utils/strings";
 
 export type CustomTextProps = Omit<EditableTextProps, "onSave" | "text">;
 export type EditableDocProps<D extends Content> =
@@ -29,6 +32,38 @@ export const EditableDocPropFor = <
             ref={ref} />
     };
     return forwardRef(typedRender);
+};
+
+export const EditableDocPropWithStyle = <
+    D extends Content,
+    O extends {value: string | undefined; label: string;}[],
+    K extends KeysWithValsOfType<D, string | undefined> = KeysWithValsOfType<D, string | undefined>,
+>(prop: K, options: O, label?: string, defaultValue?: O[number], defaultProps?: CustomTextProps) => {
+    const typedRender = <D extends Content>({doc, update, ...rest}: EditableDocProps<D>) => {
+        const docProp = doc[prop] as string | undefined;
+        const id = generateGuid();
+        return <div className="d-flex align-items-center mb-3">
+            <Label for={id} className="m-0 mr-2">{label || "Select style:"}</Label>
+            <Select inputId={id}
+                isClearable
+                onChange={option => {
+                    update({
+                        ...doc,
+                        [prop]: option?.value ? `${docProp?.split("/")[0]}/${option.value}` : docProp?.split("/")[0]
+                        // if using the undefined (default) option, remove the style from the docProp
+                    });
+                }}
+                value={options.find(o => o.value === docProp?.split("/")[1]) ?? defaultValue}
+                options={options}
+                placeholder={"Select style..."}
+                menuPortalTarget={document.body}
+                styles={{menuPortal: (base) => ({...base, zIndex: 10})}}
+                {...defaultProps}
+                {...rest}
+            />
+        </div>;
+    };
+    return typedRender;
 };
 
 function arrayWith<T>(array: T[], index: number, value: T): T[] {

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -370,6 +370,6 @@ export function getEntryType(doc: ContentType | Content) {
     if (typeof doc === "string") {
         return REGISTRY[doc];
     }
-    const typeWithLayout = `${doc.type}$${doc.layout}` as ContentType;
+    const typeWithLayout = `${doc.type}$${doc.layout?.includes("/") ? doc.layout?.slice(0, doc.layout.indexOf("/")) : doc.layout}` as ContentType;
     return REGISTRY[typeWithLayout] || REGISTRY[doc.type as ContentType] || unknown;
 }


### PR DESCRIPTION
The format is `"layout": "tabs/{style}"`, with the idea being any style is **visual only** and thus should not need any additional properties than the regular `Tabs` styling (or equivalent). 