### PR TITLE
Add templates for new doc types

### DIFF
--- a/src/components/semantic/presenters/SidebarPresenters.tsx
+++ b/src/components/semantic/presenters/SidebarPresenters.tsx
@@ -1,6 +1,6 @@
 import React from "react";
 import { SidebarEntry, Sidebar, SidebarGroup } from "../../../isaac-data-types";
-import { EditableDocPropFor, EditableTitleProp } from "../props/EditableDocProp";
+import { EditableDocPropFor, EditableIDProp, EditableSubtitleProp, EditableTitleProp } from "../props/EditableDocProp";
 import { EnumPropFor } from "../props/EnumProp";
 import { ListPresenterProp } from "../props/listProps";
 import { PresenterProps } from "../registry";
@@ -18,7 +18,18 @@ const EditableSidebarEntryPageIdProp = EditableDocPropFor<SidebarEntry>("pageId"
 const EditableSidebarEntryPageTypeProp = EnumPropFor<SidebarEntry>("pageType", SidebarEntryType)
 
 export function SidebarPresenter(props: PresenterProps<Sidebar>) {
-    return <ListPresenterProp {...props} prop="sidebarEntries" childTypeOverride="sidebarEntry" />
+    return <>
+        <h4>Sidebar</h4>
+        <div className="d-flex mb-2">
+            Sidebar ID: &nbsp;
+            <EditableIDProp {...props} placeHolder="Enter ID..." />
+        </div>
+        <div className="d-flex mb-2">
+            Mobile &quot;open sidebar&quot; button text: &nbsp;
+            <EditableSubtitleProp {...props} placeHolder="Enter button text..." />
+        </div>
+        <ListPresenterProp {...props} prop="sidebarEntries" childTypeOverride="sidebarEntry" />
+    </>
 }
 
 export function SidebarEntryPresenter(props: PresenterProps<SidebarEntry>) {

--- a/src/services/commands.ts
+++ b/src/services/commands.ts
@@ -50,8 +50,8 @@ async function doNew(context: ContextType<typeof AppContext>, action: ActionFor<
                     body: "What type of page would you like to create?",
                     options: [
                         {
-                            caption: "Wildcard",
-                            value: "isaacWildcard"
+                            caption: "General",
+                            value: "page"
                         },
                         {
                             caption: "Question",
@@ -66,29 +66,45 @@ async function doNew(context: ContextType<typeof AppContext>, action: ActionFor<
                             value: "isaacConceptPage"
                         },
                         {
-                            caption: "Topic Summary",
-                            value: "isaacTopicSummaryPage"
-                        },
-                        {
                             caption: "Test",
                             value: "isaacQuiz"
                         },
                         {
-                            caption: "General",
-                            value: "page"
+                            caption: "Book Index",
+                            value: "isaacBookIndexPage"
+                        },
+                        {
+                            caption: "Book Detail",
+                            value: "isaacBookDetailPage"
+                        },
+                        {
+                            caption: "Revision",
+                            value: "isaacRevisionDetailPage"
+                        },
+                        {
+                            caption: "Topic Summary",
+                            value: "isaacTopicSummaryPage"
                         },
                         {
                             caption: "Event",
                             value: "isaacEventPage"
                         },
                         {
-                            caption: "Email template",
+                            caption: "Sidebar",
+                            value: "sidebar"
+                        },
+                        {
+                            caption: "News Pod",
+                            value: "isaacPod"
+                        },
+                        {
+                            caption: "Email",
                             value: "emailTemplate"
                         },
                         {
-                            caption: "News pod",
-                            value: "isaacPod"
-                        }
+                            caption: "Wildcard",
+                            value: "isaacWildcard"
+                        },
                     ],
                     callback: async (option) => {
                         if (option === null) {

--- a/src/services/emptyDocuments.ts
+++ b/src/services/emptyDocuments.ts
@@ -94,6 +94,59 @@ const emptyDocuments: Document[] = [
         ],
     } as Document,
     {
+        type: "isaacBookIndexPage",
+        encoding: "markdown",
+        title: "New Book Index Page",
+        coverImage: {
+            src: "",
+            type: "image",
+            altText: ""
+        },
+        children: [
+            {
+                type: "content",
+                encoding: "markdown",
+                value: "Add page content here",
+            } as Content,
+        ],
+        sidebar: "",
+    } as Document,
+    {
+        type: "isaacBookDetailPage",
+        encoding: "markdown",
+        title: "New Book Detail Page",
+        children: [
+            {
+                type: "content",
+                encoding: "markdown",
+                value: "Add page content here"
+            } as Content,
+        ],
+        gameboards: [],
+        extensionGameboards: [],
+        sidebar: "",
+    } as Document,
+    {
+        type: "isaacRevisionDetailPage",
+        encoding: "markdown",
+        title: "New Revision Page",
+        children: [
+            {
+                type: "content",
+                encoding: "markdown",
+                value: "Add page content here"
+            } as Content
+        ],
+        gameboards: [],
+        sidebar: "",
+    } as Document,
+    {
+        type: "sidebar",
+        title: "",
+        subtitle: "View contents",
+        sidebarEntries: []
+    } as Document,
+    {
         layout: "1-col",
         title: "Event Title Here",
         subtitle: "Some subtitle",


### PR DESCRIPTION
Adds templates for:
- `isaacBookIndexPage`
- `isaacBookDetailPage`
- `isaacRevisionDetailPage`
- `sidebar`

Also rearranges the order in which templates are displayed to prioritise common ones, and adds ID and subtitle parameters to the sidebar presenter.