### PR TITLE
Move question text to top of coordinate question inputs

### DIFF
--- a/src/components/semantic/presenters/questionPresenters.tsx
+++ b/src/components/semantic/presenters/questionPresenters.tsx
@@ -333,14 +333,18 @@ export function CoordinateQuestionPresenter(props: PresenterProps<IsaacCoordinat
                 </div>
             </div>
         </div>
-        <div className={styles.questionLabel} /> {/* For spacing */}
-        <CoordinateQuestionContext.Provider value={{
+    </>;
+}
+
+export function CoordinateQuestionFooterPresenter(props: PresenterProps<IsaacCoordinateQuestion>) {
+    const question = props.doc as IsaacCoordinateQuestion;
+
+    return <CoordinateQuestionContext.Provider value={{
             numberOfCoordinates: question.numberOfCoordinates,
             numberOfDimensions: question.numberOfDimensions
         }}>
             <QuestionFooterPresenter {...props} />
-        </CoordinateQuestionContext.Provider>
-    </>;
+        </CoordinateQuestionContext.Provider>;
 }
 
 export function CoordinateChoiceItemInserter({insert, position, lengthOfCollection}: InserterProps) {

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -1,6 +1,7 @@
 import {
     AnswerPresenter,
     CoordinateQuestionPresenter,
+    CoordinateQuestionFooterPresenter,
     GraphSketcherQuestionPresenter,
     HintsPresenter,
     InlineQuestionPartPresenter,
@@ -388,7 +389,7 @@ export const REGISTRY: Record<ContentType, RegistryEntry> = {
     isaacClozeQuestion: isaacItemQuestion,
     coordinateItem$choice: {bodyPresenter: CoordinateItemPresenter},
     coordinateChoice: choice,
-    isaacCoordinateQuestion: {...question, headerPresenter: CoordinateQuestionPresenter, footerPresenter: undefined},
+    isaacCoordinateQuestion: {...question, headerPresenter: CoordinateQuestionPresenter, footerPresenter: CoordinateQuestionFooterPresenter},
     item,
     parsonsItem: item,
     item$choice: {bodyPresenter: ItemChoicePresenter},


### PR DESCRIPTION
The problem here is that the `QuestionFooterPresenter` for coordinate questions needs to be wrapped in a `CoordinateQuestionContext`. This means it needs a custom presenter. Previously this was included in `CoordinateQuestionPresenter` which keeps things neater, but because this is used as a header presenter, it was pushing the question text to the bottom of the inputs. This PR moves the footer into a separate presenter component to avoid this issue.