### PR TITLE
Add bracket-counting error to markingFormula validation

### DIFF
--- a/src/components/semantic/presenters/LLMQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/LLMQuestionPresenter.tsx
@@ -106,6 +106,8 @@ export function LLMQuestionPresenter(props: PresenterProps<IsaacLLMFreeTextQuest
             return;
         }
 
+        const openBracketsCount = value.split('(').length - 1;
+        const closeBracketsCount = value.split(')').length - 1;
         const regexStr = /[^a-zA-Z0-9(),\s]+/;
         const badCharacters = new RegExp(regexStr);
         if (badCharacters.test(value)) {
@@ -118,7 +120,10 @@ export function LLMQuestionPresenter(props: PresenterProps<IsaacLLMFreeTextQuest
                     }
                 }
             }
-            return 'Some of the characters you are using are not allowed: ' + usedBadChars.join(" ");
+            errors.push('Some of the characters you are using are not allowed: ' + usedBadChars.join(" "));
+        }
+        if (openBracketsCount !== closeBracketsCount) {
+            errors.push('You are missing some ' + (closeBracketsCount > openBracketsCount ? 'opening' : 'closing') + ' brackets.');
         }
         try { 
             const formula = parseMarkingFormula(value);

--- a/src/components/semantic/presenters/LLMQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/LLMQuestionPresenter.tsx
@@ -110,6 +110,7 @@ export function LLMQuestionPresenter(props: PresenterProps<IsaacLLMFreeTextQuest
         const closeBracketsCount = value.split(')').length - 1;
         const regexStr = /[^a-zA-Z0-9(),\s]+/;
         const badCharacters = new RegExp(regexStr);
+        const errors: string[] = [];
         if (badCharacters.test(value)) {
             const usedBadChars: string[] = [];
             for(let i = 0; i < value.length; i++) {
@@ -132,7 +133,13 @@ export function LLMQuestionPresenter(props: PresenterProps<IsaacLLMFreeTextQuest
                                                         });
         } 
         catch (e: any) { 
-            return `${e}`;
+            if (errors.length === 0) errors.push(`${e}`);
+        }
+
+        if (errors.length === 0) {
+            return;
+        } else {
+            return errors;
         }
     }
 
@@ -167,7 +174,7 @@ export function LLMQuestionPresenter(props: PresenterProps<IsaacLLMFreeTextQuest
                     <td>
                         <pre><EditableText
                             text={mark.jsonField}
-                            hasError={value => !value?.match(/^[a-z][a-zA-Z0-9]+$/) ? "Invalid JSON fieldname format" : undefined}
+                            hasError={value => !value?.match(/^[a-z][a-zA-Z0-9]+$/) ? ["Invalid JSON fieldname format"] : undefined}
                             onSave={value => updateMark(i, "jsonField", value)}
                         /></pre>
                     </td>
@@ -276,7 +283,7 @@ export function LLMQuestionPresenter(props: PresenterProps<IsaacLLMFreeTextQuest
                                 :
                                 <EditableText
                                     text={example.marksAwarded?.toString()}
-                                    hasError={value => doc.maxMarks && parseInt(value ?? "0", 10) > doc.maxMarks ? "Exceeds question's max marks" : undefined}
+                                    hasError={value => doc.maxMarks && parseInt(value ?? "0", 10) > doc.maxMarks ? ["Exceeds question's max marks"] : undefined}
                                     onSave={value => updateExample(i, "marksAwarded", parseInt(value ?? "0", 10))}
                                 />}
                             </div>

--- a/src/components/semantic/presenters/LLMQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/LLMQuestionPresenter.tsx
@@ -287,7 +287,9 @@ export function LLMQuestionPresenter(props: PresenterProps<IsaacLLMFreeTextQuest
                                     onSave={value => updateExample(i, "marksAwarded", parseInt(value ?? "0", 10))}
                                 />}
                             </div>
-                            <button className="btn btn-sm mb-2 ml-2" onClick={() => deleteExample(i)}>❌</button>
+                            <div>
+                                <button className="btn btn-sm mb-2 ml-2" onClick={() => deleteExample(i)}>❌</button>
+                            </div>
                         </div>
                     </td>
                 </tr>)}

--- a/src/components/semantic/props/EditableText.tsx
+++ b/src/components/semantic/props/EditableText.tsx
@@ -19,6 +19,7 @@ import {Markup} from "../../../isaac/markup";
 import CodeMirror, {EditorView} from "@uiw/react-codemirror";
 import {MarkupToolbar} from "../../MarkupToolbar";
 import {keyBindings} from "../../../utils/codeMirrorExtensions";
+import { isDefined } from "../../../utils/types";
 
 export interface SaveOptions {
     movement?: number;
@@ -42,7 +43,7 @@ export type EditableTextProps = {
     placeHolder?: string;
     onDelete?: (options?: SaveOptions) => void;
     autoFocus?: boolean;
-    hasError?: (newText: string | undefined) => string | undefined;
+    hasError?: (newText: string | undefined) => string[] | undefined;
     label?: string;
     noSupressSaves?: boolean;
     hideWhenEmpty?: boolean
@@ -107,7 +108,7 @@ export const EditableText = forwardRef<EditableTextRef, EditableTextProps>(({
                                  buttonStrings = [],
                              }, ref) => {
     const wrapperRef = useRef<HTMLDivElement>(null);
-    const [errorMessage, setErrorMessage] = useState<string>();
+    const [errorMessage, setErrorMessage] = useState<string[]>();
 
     const onSave = useWrappedRef(onSaveUnsafe);
     const onDelete = useWrappedRef(onDeleteUnsafe);
@@ -243,17 +244,19 @@ export const EditableText = forwardRef<EditableTextRef, EditableTextProps>(({
                                     onKeyDown={handleKey}
                                     placeholder={placeHolder}
                                     onBlur={onBlur}
-                                    invalid={!!errorMessage}
+                                    invalid={errorMessage && errorMessage.length > 0}
                                     {...inputProps}
                                 />
                             }
                         </>
                     </span>
-                    {errorMessage && <FormFeedback className={styles.feedback}>{errorMessage}</FormFeedback>}
                 </span>
                 <Button onClick={cancel}>Cancel</Button>
                 <Button color="primary" onClick={() => save()}>Set</Button>
             </Wrap>
+            {isDefined(errorMessage) && errorMessage.length > 0 && <Wrap className="pb-2">
+                {errorMessage.map(e => <FormFeedback key={e} className={classNames(styles.feedback, "d-block")}>{e}</FormFeedback>)}
+            </Wrap>}
             <Wrap ref={wrapperRef} className={`justify-content-start ${styles.isEditingWrapper}`}>
                 {insertStringButtons}
             </Wrap>

--- a/src/components/semantic/props/EditableText.tsx
+++ b/src/components/semantic/props/EditableText.tsx
@@ -217,7 +217,7 @@ export const EditableText = forwardRef<EditableTextRef, EditableTextProps>(({
     const Wrap = block ? "div" : "span";
     if (state.isEditing) {
         return <> <Wrap ref={wrapperRef} className={`${styles.isEditingWrapper} ${multiLine ? styles.multiLine : ""}`}>
-                <span className={classNames(styles.controlWrapper, format === "code" ? "w-100" : "")}>
+                <span className={classNames(styles.controlWrapper, format === "code" ? "w-100" : "", "pb-2")}>
                     <span className={styles.labelledInput}>
                         <>
                             {multiLine ? labelElement : <div>{labelElement}</div>}
@@ -251,8 +251,8 @@ export const EditableText = forwardRef<EditableTextRef, EditableTextProps>(({
                         </>
                     </span>
                 </span>
-                <Button onClick={cancel}>Cancel</Button>
-                <Button color="primary" onClick={() => save()}>Set</Button>
+                <Button className="mb-2" onClick={cancel}>Cancel</Button>
+                <Button className="mb-2" color="primary" onClick={() => save()}>Set</Button>
             </Wrap>
             {isDefined(errorMessage) && errorMessage.length > 0 && <Wrap className="pb-2">
                 {errorMessage.map(e => <FormFeedback key={e} className={classNames(styles.feedback, "d-block")}>{e}</FormFeedback>)}

--- a/src/components/semantic/props/NumberDocPropFor.tsx
+++ b/src/components/semantic/props/NumberDocPropFor.tsx
@@ -20,7 +20,7 @@ export const NumberDocPropFor = <D extends Content,
                     newText = newText.trim();
                     const num = parseInt(newText, 10);
                     if (isNaN(num) || num.toString() !== newText) {
-                        return "Not a number";
+                        return ["Not a number"];
                     }
                 }
             }}


### PR DESCRIPTION
Also adds support for multiple errors to be displayed at once. This may be helpful if we want to add more errors here, or some to the `CodeMirror` editor.

Largely taken from `IsaacSymbolicQuestion.tsx` in react-app so it should be consistent with that.