### PR TITLE
Add "decorative" checkbox to set empty alt text

### DIFF
--- a/src/components/semantic/SemanticItem.tsx
+++ b/src/components/semantic/SemanticItem.tsx
@@ -44,7 +44,7 @@ import {ContentType, getEntryType} from "./registry";
 import {JSONEditor} from "./JSONEditor";
 
 import styles from "./styles/semantic.module.css";
-import {MetadataPresenter} from "./Metadata";
+import {MetaItemKey, MetadataPresenter} from "./Metadata";
 import classNames from "classnames";
 
 interface Shift {
@@ -112,10 +112,6 @@ function SemanticItemInner(props: SemanticItemProps) {
 
     const entryType = getEntryType(typeOverride ?? doc);
 
-    const metadata = entryType.metadata;
-    const meta = metadata && showMeta && !jsonMode && <div className={styles.metadata}>
-        <MetadataPresenter {...subProps} metadata={metadata} />
-    </div>;
 
     const HeaderPresenter = entryType.headerPresenter;
     const header = !jsonMode && HeaderPresenter ? <HeaderPresenter {...subProps} /> : null;
@@ -125,6 +121,11 @@ function SemanticItemInner(props: SemanticItemProps) {
 
     const FooterPresenter = entryType.footerPresenter;
     const footer = !jsonMode && FooterPresenter ? <FooterPresenter {...subProps} /> : null;
+
+    const metadata = ((BodyPresenter as {filterMetadata?: (metadata: string[] | undefined, doc: Content) => string[] | undefined} | undefined)?.filterMetadata?.(entryType.metadata, doc) ?? entryType.metadata) as MetaItemKey[] | undefined;
+    const meta = metadata && showMeta && !jsonMode && <div className={styles.metadata}>
+        <MetadataPresenter {...subProps} metadata={metadata} />
+    </div>;
 
     // Render outline with type name
     const BoxedItem = <Box

--- a/src/components/semantic/SemanticItem.tsx
+++ b/src/components/semantic/SemanticItem.tsx
@@ -122,7 +122,9 @@ function SemanticItemInner(props: SemanticItemProps) {
     const FooterPresenter = entryType.footerPresenter;
     const footer = !jsonMode && FooterPresenter ? <FooterPresenter {...subProps} /> : null;
 
-    const metadata = ((BodyPresenter as {filterMetadata?: (metadata: string[] | undefined, doc: Content) => string[] | undefined} | undefined)?.filterMetadata?.(entryType.metadata, doc) ?? entryType.metadata) as MetaItemKey[] | undefined;
+    const metadata = entryType.metadata
+        ?.map(m => typeof m === "function" ? m(doc) : m)
+        .filter(Boolean) as MetaItemKey[];
     const meta = metadata && showMeta && !jsonMode && <div className={styles.metadata}>
         <MetadataPresenter {...subProps} metadata={metadata} />
     </div>;

--- a/src/components/semantic/presenters/FigurePresenter.tsx
+++ b/src/components/semantic/presenters/FigurePresenter.tsx
@@ -189,6 +189,15 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
         ? <Alert color="info"><small>Figure is in a non-static context, so cannot be given a number</small></Alert>
         : <h6>{figureNumber ? `Figure ${figureNumber}` : "Set ID to get a figure number"}</h6>;
 
+    (FigurePresenter as typeof FigurePresenter & {
+        filterMetadata?: (metadata: string[] | undefined, doc: Figure) => string[] | undefined;
+    }).filterMetadata = (metadata, doc) => {
+        if (doc.altText === "") {
+            return metadata?.filter((item) => item !== "altText");
+        }
+        return metadata;
+    };
+
     return <>
         <div className={styles.figureWrapper}>
             <div className={styles.figureImage}>

--- a/src/components/semantic/presenters/FigurePresenter.tsx
+++ b/src/components/semantic/presenters/FigurePresenter.tsx
@@ -189,15 +189,6 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
         ? <Alert color="info"><small>Figure is in a non-static context, so cannot be given a number</small></Alert>
         : <h6>{figureNumber ? `Figure ${figureNumber}` : "Set ID to get a figure number"}</h6>;
 
-    (FigurePresenter as typeof FigurePresenter & {
-        filterMetadata?: (metadata: string[] | undefined, doc: Figure) => string[] | undefined;
-    }).filterMetadata = (metadata, doc) => {
-        if (doc.altText === "") {
-            return metadata?.filter((item) => item !== "altText");
-        }
-        return metadata;
-    };
-
     return <>
         <div className={styles.figureWrapper}>
             <div className={styles.figureImage}>

--- a/src/components/semantic/presenters/FigurePresenter.tsx
+++ b/src/components/semantic/presenters/FigurePresenter.tsx
@@ -12,7 +12,7 @@ import { useFixedRef } from "../../../utils/hooks";
 
 import styles from "../styles/figure.module.css";
 import {NON_STATIC_FIGURE_FLAG} from "../../../isaac/IsaacTypes";
-import {Alert} from "reactstrap";
+import {Alert, Input, Label} from "reactstrap";
 import { DropZoneQuestionContext } from "./ItemQuestionPresenter";
 import { FigureRegionModal } from "../../FigureRegionModal";
 import { InlineQuestionContext } from "./questionPresenters";
@@ -232,5 +232,27 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
                 regions={figureRegions} setRegions={setFigureRegions} figureNum={typeof figureNumber === "number" ? figureNumber : undefined}
             />}
         </div>}
+
+        {/*Set alt text to empty string for decorative images*/}
+        <Label>
+            <Input type="checkbox"
+                checked={doc.altText === ""}
+                onChange={(e) => {
+                    if (e.target.checked) {
+                        update({
+                            ...doc,
+                            altText: "",
+                        });
+                    } else {
+                        update({
+                            ...doc,
+                            altText: undefined,
+                        });
+                    }
+                }}
+                className="me-1"
+            />
+            Decorative (sets empty alt text)
+        </Label>
     </>;
 }

--- a/src/components/semantic/presenters/FigurePresenter.tsx
+++ b/src/components/semantic/presenters/FigurePresenter.tsx
@@ -246,7 +246,7 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
                     } else {
                         update({
                             ...doc,
-                            altText: undefined,
+                            altText: doc.altText === "" ? undefined : doc.altText,
                         });
                     }
                 }}

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -21,7 +21,7 @@ import {CHOICE_TYPES} from "./ChoiceInserter";
 import {TabsPresenter} from "./presenters/TabsPresenter";
 import React, {FunctionComponent, Provider} from "react";
 import {ChoicePresenter, CoordinateItemPresenter} from "./presenters/ChoicePresenter";
-import {Content} from "../../isaac-data-types";
+import {Content, Figure} from "../../isaac-data-types";
 import {FigurePresenter} from "./presenters/FigurePresenter";
 import {ValuePresenter} from "./presenters/BaseValuePresenter";
 import {ContentValueOrChildrenPresenter} from "./presenters/ContentValueOrChildrenPresenter";
@@ -113,7 +113,7 @@ interface RegistryEntry {
     bodyPresenter?: ValuePresenter;
     footerPresenter?: Presenter;
     blankValue?: string;
-    metadata?: MetaItemKey[];
+    metadata?: (MetaItemKey | ((doc: Content) => MetaItemKey | undefined))[];
     contextProviderWrapper?: Provider<Content | null>;
     className?: string;
 }
@@ -194,7 +194,12 @@ const figure: RegistryEntry = {
     name: "Figure",
     bodyPresenter: FigurePresenter,
     blankValue: "Enter caption here",
-    metadata: mediaMeta,
+    metadata: (mediaMeta as RegistryEntry['metadata'])?.toSpliced(
+        // hide altText if doc.altText is the empty string (i.e. has been marked as decorative)
+        mediaMeta.indexOf("altText"), 
+        1, 
+        (doc: Figure) => (doc.altText === "" ? undefined : "altText")
+    ),
 };
 const video: RegistryEntry = {
     name: "Video",


### PR DESCRIPTION
Adds a checkbox to mark images as decorative, which sets the `altText` attribute to the empty string to avoid having to manually set and unset alt text to achieve the same result.

This doesn't suppress the "missing alt text" content error, which might be a good idea, but would require adding a new `decorative` property to `Image` (or `Figure`) and modifying the content indexer.