### PR TITLE
Auto-generate GUIDs for videos

### DIFF
--- a/src/components/semantic/presenters/VideoPresenter.tsx
+++ b/src/components/semantic/presenters/VideoPresenter.tsx
@@ -7,11 +7,17 @@ import {
 } from "../props/EditableDocProp";
 import styles from "../styles/figure.module.css";
 import { PresenterProps } from "../registry";
+import { isDefined } from "../../../utils/types";
+import { generateGuid } from "../../../utils/strings";
 
 const EditableSrc = EditableDocPropFor<Video>("src");
 const EditableAltText = EditableDocPropFor<Video>("altText");
 
 export function VideoPresenter(props: PresenterProps<Video>) {
+    if (!isDefined(props.doc.id)) {
+        props.update({...props.doc, id: generateGuid()});
+    }
+
     return <>
         <div className={styles.figureWrapper}>
             <div className={styles.figureImage}>


### PR DESCRIPTION
If a video ID is blank at the point of ETL ingestion, an ID is generated based on the parent ID and the video's source bytes. This means that if the same video occurs twice within the same parent, the videos get assigned the same ID, causing a content error.

To avoid this issue entirely, we should just generate GUIDs for videos in the editor, which can be overridden as desired.