### PR TITLE
Make "decorative" checkbox set property on media

### DIFF
--- a/src/components/semantic/presenters/FigurePresenter.tsx
+++ b/src/components/semantic/presenters/FigurePresenter.tsx
@@ -246,11 +246,13 @@ export function FigurePresenter(props: PresenterProps<Figure>) {
                     if (e.target.checked) {
                         update({
                             ...doc,
+                            decorative: true,
                             altText: "",
                         });
                     } else {
                         update({
                             ...doc,
+                            decorative: false,
                             altText: doc.altText === "" ? undefined : doc.altText,
                         });
                     }

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -446,6 +446,7 @@ export interface LogicFormula extends Choice {
 export interface Media extends Content {
     src?: string;
     altText?: string;
+    decorative?: boolean;
 }
 
 export interface Notification extends Content {


### PR DESCRIPTION
so that we can ignore decorative images with blank alt text in content errors.

Note that for images that have previously been marked as decorative, the property won't be set unless the checkbox is unchecked & rechecked.

see https://github.com/isaacphysics/isaac-api/pull/800