### PR TITLE
Add drop-zone button improvements

### DIFF
--- a/src/components/MarkupToolbar.tsx
+++ b/src/components/MarkupToolbar.tsx
@@ -75,7 +75,7 @@ export const MarkupToolbar = ({set, cancel, codemirror, encoding, value}: { set:
             </button>
             {encodingSpecific(
                 <>
-                    {isClozeQuestion || isDndQuestion && <PopupDropZoneInsert wide={wide} codemirror={codemirror}/>}
+                    {(isClozeQuestion || isDndQuestion) && <PopupDropZoneInsert wide={wide} codemirror={codemirror}/>}
                     {inlineContext.isInlineQuestion && <PopupInlineQuestionInsert wide={wide} codemirror={codemirror}/>}
                     {value?.includes("<table") && <PopupTableClass wide={wide} codemirror={codemirror}/>}
                     <PopupGlossaryTermSelect wide={wide} codemirror={codemirror}/>

--- a/src/components/MarkupToolbar.tsx
+++ b/src/components/MarkupToolbar.tsx
@@ -17,7 +17,7 @@ import { PopupInlineQuestionInsert } from "./popups/PopupInlineQuestionInsert";
 import { PopupTableClass } from "./popups/PopupTableClass";
 
 export const MarkupToolbar = ({set, cancel, codemirror, encoding, value}: { set: () => void, cancel: () => void, codemirror?: RefObject<ReactCodeMirrorRef>, encoding: string | undefined, value?: string }) => {
-    const {isClozeQuestion} = useContext(DropZoneQuestionContext);
+    const {isClozeQuestion, isDndQuestion} = useContext(DropZoneQuestionContext);
     const inlineContext = useContext(InlineQuestionContext);
 
     const [wide, setWide] = useState(true);
@@ -75,7 +75,7 @@ export const MarkupToolbar = ({set, cancel, codemirror, encoding, value}: { set:
             </button>
             {encodingSpecific(
                 <>
-                    {isClozeQuestion && <PopupDropZoneInsert wide={wide} codemirror={codemirror}/>}
+                    {isClozeQuestion || isDndQuestion && <PopupDropZoneInsert wide={wide} codemirror={codemirror}/>}
                     {inlineContext.isInlineQuestion && <PopupInlineQuestionInsert wide={wide} codemirror={codemirror}/>}
                     {value?.includes("<table") && <PopupTableClass wide={wide} codemirror={codemirror}/>}
                     <PopupGlossaryTermSelect wide={wide} codemirror={codemirror}/>

--- a/src/components/popups/Popup.tsx
+++ b/src/components/popups/Popup.tsx
@@ -17,7 +17,11 @@ export interface PopupRef {
     open: (event: React.MouseEvent) => void
 }
 
-export function Popup({ popUpRef, children }: { popUpRef: MutableRefObject<PopupRef | null>; children: ReactNode }) {
+export function Popup({ popUpRef, children, onClose }: { 
+    popUpRef: MutableRefObject<PopupRef | null>;
+    children: ReactNode;
+    onClose?: () => void; 
+}) {
     const [isOpen, setOpen] = useState(false);
     const [anchorPoint, setAnchorPoint] = useState({x: 0, y: 0});
     const [height, setHeight] = useState<number>();
@@ -33,10 +37,14 @@ export function Popup({ popUpRef, children }: { popUpRef: MutableRefObject<Popup
         if (insideRef.current?.contains(event.target as Node)) {
             return;
         }
+
+        onClose?.();
         setOpen(false);
+
         event.stopPropagation();
         event.preventDefault();
-    }, []);
+    }, [onClose]);
+
     useLayoutEffect(() => {
         if (isOpen) {
             const tempAnchor = {x: anchorPoint.x, y: anchorPoint.y};
@@ -68,8 +76,9 @@ export function Popup({ popUpRef, children }: { popUpRef: MutableRefObject<Popup
     }), [handleContextMenu]);
 
     const close = useCallback(() => {
+        onClose?.();
         setOpen(false);
-    }, []);
+    }, [onClose]);
 
     return isOpen ?
         <Portal>

--- a/src/components/popups/PopupDropZoneInsert.tsx
+++ b/src/components/popups/PopupDropZoneInsert.tsx
@@ -1,13 +1,13 @@
 import React, {RefObject, useCallback, useContext, useRef, useState} from "react";
 import {Popup, PopupCloseContext, PopupRef} from "./Popup";
-import {Button, Container, Input, InputGroup, Label} from "reactstrap";
+import {Alert, Button, Container, Input, InputGroup, Label} from "reactstrap";
 import {ReactCodeMirrorRef} from "@uiw/react-codemirror";
 import styles from "../../styles/editor.module.css";
 import { DropZoneQuestionContext } from "../semantic/presenters/ItemQuestionPresenter";
 
 export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemirror: RefObject<ReactCodeMirrorRef> }) => {
     const popupRef = useRef<PopupRef>(null);
-    const {isDndQuestion, dropZoneIds} = useContext(DropZoneQuestionContext);
+    const {isDndQuestion, isClozeQuestion, dropZoneIds} = useContext(DropZoneQuestionContext);
 
     const updatedDropZoneIds = useRef<Set<string>>(dropZoneIds);
 
@@ -48,7 +48,6 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
         } else {
             setValid(false);
         }
-
     };
 
     return <>
@@ -57,20 +56,22 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
         }}>{wide ? `Add ${isDndQuestion ? "DnD" : "cloze"} drop-zone` : "➕ drop-zone"}</button>
         <Popup popUpRef={popupRef}>
             <Container className={styles.cmPanelPopup}>
-                {isDndQuestion && <>
-                    <Label for={"drop-zone-id"}>Drop-zone ID:</Label>
-                    <Input id={"drop-zone-id"} defaultValue={nextDropZoneId()} onChange={(e) => setId(e.target.value)} />
-                    <hr/>
-                </>}
                 <Label for={"drop-zone-width"}>Width:</Label>
                 <Input id={"drop-zone-width"} placeholder={"Default"} onChange={ifValidNumericalInputThen(setWidth)}/>
-                <hr/>
-                <Label for={"drop-zone-height"}>Height:</Label>
+                <Label className="mt-2" for={"drop-zone-height"}>Height:</Label>
                 <Input id={"drop-zone-height"} placeholder={"Default"} onChange={ifValidNumericalInputThen(setHeight)} />
                 <hr/>
-                <Label for={"drop-zone-index"}>Index override:</Label>
-                <Input id={"drop-zone-index"} placeholder={"None"} onChange={ifValidNumericalInputThen(setIndex)} />
-                <hr/>
+                {isClozeQuestion && <>
+                    <Label for={"drop-zone-index"}>Index override:</Label>
+                    <Input id={"drop-zone-index"} placeholder={"None"} onChange={ifValidNumericalInputThen(setIndex)} />
+                    <hr/>
+                </>}
+                {isDndQuestion && <>
+                    <Label for={"drop-zone-id"}>Drop-zone ID:</Label>
+                    <Input id={"drop-zone-id"} defaultValue={nextDropZoneId()} onChange={(e) => {setId(e.target.value); setValid(!!e.target.value)}} />
+                    {!id && <Alert className="mt-1" color="danger">Missing ID field</Alert>}
+                    <hr/>
+                </>}
                 <InputGroup className={"ps-4"}>
                     <Label for={"drop-zone-in-latex"}>Inside LaTeX?:</Label>
                     <Input type={"checkbox"} id={"drop-zone-in-latex"} onChange={() => setInLatex(b => !b)} checked={inLatex} />

--- a/src/components/popups/PopupDropZoneInsert.tsx
+++ b/src/components/popups/PopupDropZoneInsert.tsx
@@ -1,11 +1,15 @@
-import React, {RefObject, useCallback, useRef, useState} from "react";
+import React, {RefObject, useCallback, useContext, useRef, useState} from "react";
 import {Popup, PopupCloseContext, PopupRef} from "./Popup";
 import {Button, Container, Input, InputGroup, Label} from "reactstrap";
 import {ReactCodeMirrorRef} from "@uiw/react-codemirror";
 import styles from "../../styles/editor.module.css";
+import { DropZoneQuestionContext } from "../semantic/presenters/ItemQuestionPresenter";
 
 export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemirror: RefObject<ReactCodeMirrorRef> }) => {
     const popupRef = useRef<PopupRef>(null);
+    const {isDndQuestion, dropZoneIds} = useContext(DropZoneQuestionContext);
+
+    const updatedDropZoneIds = useRef<Set<string>>(dropZoneIds);
 
     const [width, setWidth] = useState<number>();
     const [height, setHeight] = useState<number>();
@@ -13,12 +17,28 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
     const [valid, setValid] = useState<boolean>(true);
     const [inLatex, setInLatex] = useState<boolean>(false);
 
+    const nextDropZoneId = useCallback(() => {
+        let nextId = "A1";
+        while (updatedDropZoneIds.current?.has(nextId)) {
+            const number = parseInt(nextId.substring(1));
+            nextId = `A${number + 1}`;
+        }
+        return nextId;
+    }, [updatedDropZoneIds]);
+    const [id, setId] = useState<string>(nextDropZoneId());
+
     const generateAndInsertDropZone = useCallback(() => {
-        const dropZoneSyntax = `[drop-zone${(width || height || index) ? "|" : ""}${index ? `i-${index}` : ""}${width ? `w-${width}` : ""}${height ? `h-${height}` : ""}]`;
+        const dropZoneSyntax = `[drop-zone${id ? `:${id}` : ""}${(width || height || index) ? "|" : ""}${index ? `i-${index}` : ""}${width ? `w-${width}` : ""}${height ? `h-${height}` : ""}]`;
+        if (id) {
+            if (!updatedDropZoneIds.current) {
+                updatedDropZoneIds.current = new Set<string>();
+            }
+            updatedDropZoneIds.current.add(id);
+        }
         codemirror.current?.view?.dispatch(
             codemirror.current?.view?.state.replaceSelection(inLatex ? `\\text{${dropZoneSyntax}}` : dropZoneSyntax)
         );
-    }, [width, height, index, inLatex, codemirror]);
+    }, [width, height, index, id, inLatex, codemirror]);
 
     const ifValidNumericalInputThen = (f: (n: number | undefined) => void) => (e: React.ChangeEvent<HTMLInputElement>) => {
         const n = parseInt(e.target.value);
@@ -34,9 +54,14 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
     return <>
         <button className={styles.cmPanelButton} title={"Insert cloze drop-zone"} onClick={(event) => {
             popupRef.current?.open(event);
-        }}>{wide ? "Add cloze drop-zone" : "➕ drop-zone"}</button>
+        }}>{wide ? `Add ${isDndQuestion ? "DnD" : "cloze"} drop-zone` : "➕ drop-zone"}</button>
         <Popup popUpRef={popupRef}>
             <Container className={styles.cmPanelPopup}>
+                {isDndQuestion && <>
+                    <Label for={"drop-zone-id"}>Drop-zone ID:</Label>
+                    <Input id={"drop-zone-id"} defaultValue={nextDropZoneId()} onChange={(e) => setId(e.target.value)} />
+                    <hr/>
+                </>}
                 <Label for={"drop-zone-width"}>Width:</Label>
                 <Input id={"drop-zone-width"} placeholder={"Default"} onChange={ifValidNumericalInputThen(setWidth)}/>
                 <hr/>
@@ -57,6 +82,7 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
                         setWidth(undefined);
                         setHeight(undefined);
                         setIndex(undefined);
+                        setId(nextDropZoneId());
                         setInLatex(false);
                         close?.();
                     }}>

--- a/src/components/popups/PopupDropZoneInsert.tsx
+++ b/src/components/popups/PopupDropZoneInsert.tsx
@@ -72,7 +72,7 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
                 </>}
                 <InputGroup className={"ps-4"}>
                     <Label for={"drop-zone-in-latex"}>Inside LaTeX?:</Label>
-                    <Input type={"checkbox"} id={"drop-zone-in-latex"} onChange={() => setInLatex(b => !b)} checked={inLatex} />
+                    <Input type={"checkbox"} className="ms-1 rounded-1" id={"drop-zone-in-latex"} onChange={() => setInLatex(b => !b)} checked={inLatex} />
                 </InputGroup>
                 <hr/>
                 <PopupCloseContext.Consumer>

--- a/src/components/popups/PopupDropZoneInsert.tsx
+++ b/src/components/popups/PopupDropZoneInsert.tsx
@@ -11,10 +11,9 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
 
     const updatedDropZoneIds = useRef<Set<string>>(dropZoneIds);
 
-    const [width, setWidth] = useState<number>();
-    const [height, setHeight] = useState<number>();
-    const [index, setIndex] = useState<number>();
-    const [valid, setValid] = useState<boolean>(true);
+    const [width, setWidth] = useState<string>();
+    const [height, setHeight] = useState<string>();
+    const [index, setIndex] = useState<string>();
     const [inLatex, setInLatex] = useState<boolean>(false);
 
     const nextDropZoneId = useCallback(() => {
@@ -40,15 +39,11 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
         );
     }, [width, height, index, id, inLatex, codemirror]);
 
-    const ifValidNumericalInputThen = (f: (n: number | undefined) => void) => (e: React.ChangeEvent<HTMLInputElement>) => {
-        const n = parseInt(e.target.value);
-        if (!isNaN(n) || !e.target.value || e.target.value === "") {
-            setValid(true);
-            f(n);
-        } else {
-            setValid(false);
-        }
-    };
+    const widthInvalid = width && !(Number(width) > 0 && Number(width) <= 100);
+    const heightInvalid = height && !(Number(height) > 0 && Number(height) <= 100);
+    const indexInvalid = index && !Number(index);
+    const idInvalid = isDndQuestion && !id;
+    const valid = !idInvalid && !widthInvalid && !heightInvalid && !indexInvalid;
 
     return <>
         <button className={styles.cmPanelButton} title={"Insert cloze drop-zone"} onClick={(event) => {
@@ -57,19 +52,22 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
         <Popup popUpRef={popupRef}>
             <Container className={styles.cmPanelPopup}>
                 <Label for={"drop-zone-width"}>Width:</Label>
-                <Input id={"drop-zone-width"} placeholder={"Default"} onChange={ifValidNumericalInputThen(setWidth)}/>
+                <Input id={"drop-zone-width"} placeholder={"Default"} onChange={(e) => setWidth(e.target.value)} />
+                {widthInvalid && <Alert className="my-1" color="danger">Width must be a number between 1 and 100</Alert>}
                 <Label className="mt-2" for={"drop-zone-height"}>Height:</Label>
-                <Input id={"drop-zone-height"} placeholder={"Default"} onChange={ifValidNumericalInputThen(setHeight)} />
+                <Input id={"drop-zone-height"} placeholder={"Default"} onChange={(e) => setHeight(e.target.value)} />
+                {heightInvalid && <Alert className="my-1" color="danger">Height must be a number between 1 and 100</Alert>}
                 <hr/>
                 {isClozeQuestion && <>
                     <Label for={"drop-zone-index"}>Index override:</Label>
-                    <Input id={"drop-zone-index"} placeholder={"None"} onChange={ifValidNumericalInputThen(setIndex)} />
+                    <Input id={"drop-zone-index"} placeholder={"None"} onChange={(e) => setIndex(e.target.value)} />
+                    {indexInvalid && <Alert className="my-1" color="danger">Index must be a number</Alert>}
                     <hr/>
                 </>}
                 {isDndQuestion && <>
                     <Label for={"drop-zone-id"}>Drop-zone ID:</Label>
-                    <Input id={"drop-zone-id"} defaultValue={nextDropZoneId()} onChange={(e) => {setId(e.target.value); setValid(!!e.target.value)}} />
-                    {!id && <Alert className="mt-1" color="danger">Missing ID field</Alert>}
+                    <Input id={"drop-zone-id"} defaultValue={nextDropZoneId()} onChange={(e) => setId(e.target.value)} />
+                    {idInvalid && <Alert className="my-1" color="danger">Drop zone missing ID!</Alert>}
                     <hr/>
                 </>}
                 <InputGroup className={"ps-4"}>

--- a/src/components/popups/PopupDropZoneInsert.tsx
+++ b/src/components/popups/PopupDropZoneInsert.tsx
@@ -16,6 +16,14 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
     const [index, setIndex] = useState<string>();
     const [inLatex, setInLatex] = useState<boolean>(false);
 
+    const resetState = () => {
+        setWidth(undefined);
+        setHeight(undefined);
+        setIndex(undefined);
+        setId(nextDropZoneId());
+        setInLatex(false);
+    };
+
     const nextDropZoneId = useCallback(() => {
         let nextId = "A1";
         while (updatedDropZoneIds.current?.has(nextId)) {
@@ -49,7 +57,7 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
         <button className={styles.cmPanelButton} title={"Insert cloze drop-zone"} onClick={(event) => {
             popupRef.current?.open(event);
         }}>{wide ? `Add ${isDndQuestion ? "DnD" : "cloze"} drop-zone` : "➕ drop-zone"}</button>
-        <Popup popUpRef={popupRef}>
+        <Popup popUpRef={popupRef} onClose={resetState}>
             <Container className={styles.cmPanelPopup}>
                 <Label for={"drop-zone-width"}>Width:</Label>
                 <Input id={"drop-zone-width"} placeholder={"Default"} onChange={(e) => setWidth(e.target.value)} />
@@ -78,11 +86,6 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
                 <PopupCloseContext.Consumer>
                     {close => <Button disabled={!valid} onClick={() => {
                         generateAndInsertDropZone();
-                        setWidth(undefined);
-                        setHeight(undefined);
-                        setIndex(undefined);
-                        setId(nextDropZoneId());
-                        setInLatex(false);
                         close?.();
                     }}>
                         Generate drop zone

--- a/src/components/popups/PopupDropZoneInsert.tsx
+++ b/src/components/popups/PopupDropZoneInsert.tsx
@@ -39,9 +39,9 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
         );
     }, [width, height, index, id, inLatex, codemirror]);
 
-    const widthInvalid = width && !(Number(width) > 0 && Number(width) <= 100);
-    const heightInvalid = height && !(Number(height) > 0 && Number(height) <= 100);
-    const indexInvalid = index && !Number(index);
+    const widthInvalid = width && (Number.isNaN(Number(width)) || Number(width) < 0);
+    const heightInvalid = height && (Number.isNaN(Number(height)) || Number(height) < 0);
+    const indexInvalid = index && (!Number.isInteger(Number(index)) || Number(index) < 0);
     const idInvalid = isDndQuestion && !id;
     const valid = !idInvalid && !widthInvalid && !heightInvalid && !indexInvalid;
 
@@ -53,15 +53,15 @@ export const PopupDropZoneInsert = ({wide, codemirror}: { wide?: boolean, codemi
             <Container className={styles.cmPanelPopup}>
                 <Label for={"drop-zone-width"}>Width:</Label>
                 <Input id={"drop-zone-width"} placeholder={"Default"} onChange={(e) => setWidth(e.target.value)} />
-                {widthInvalid && <Alert className="my-1" color="danger">Width must be a number between 1 and 100</Alert>}
+                {widthInvalid && <Alert className="my-1" color="warning">Width must be a positive number</Alert>}
                 <Label className="mt-2" for={"drop-zone-height"}>Height:</Label>
                 <Input id={"drop-zone-height"} placeholder={"Default"} onChange={(e) => setHeight(e.target.value)} />
-                {heightInvalid && <Alert className="my-1" color="danger">Height must be a number between 1 and 100</Alert>}
+                {heightInvalid && <Alert className="my-1" color="warning">Height must be a positive number</Alert>}
                 <hr/>
                 {isClozeQuestion && <>
                     <Label for={"drop-zone-index"}>Index override:</Label>
                     <Input id={"drop-zone-index"} placeholder={"None"} onChange={(e) => setIndex(e.target.value)} />
-                    {indexInvalid && <Alert className="my-1" color="danger">Index must be a number</Alert>}
+                    {indexInvalid && <Alert className="my-1" color="warning">Index must be a positive integer</Alert>}
                     <hr/>
                 </>}
                 {isDndQuestion && <>

--- a/src/components/popups/PopupGlossaryTermSelect.tsx
+++ b/src/components/popups/PopupGlossaryTermSelect.tsx
@@ -50,6 +50,13 @@ export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, co
     const [isInlineTerm, setIsInlineTerm] = useState<boolean>(true);
     const [isTitledTerm, setIsTitledTerm] = useState<boolean>(isAda); // Ada should default to being checked
 
+    const resetState = () => {
+        setGlossaryTerm(undefined);
+        setGlossaryTermText(undefined);
+        setIsInlineTerm(true);
+        setIsTitledTerm(isAda);
+    };
+
     const generateAndInsertGlossaryTerm = useCallback(() => {
         if (glossaryTerm) {
             const trimmedGlossaryTermText = glossaryTermText?.trim();
@@ -62,7 +69,7 @@ export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, co
         <button className={styles.cmPanelButton} title={"Insert glossary term"} onClick={(event) => {
             popupRef.current?.open(event);
         }}>{wide ? "Add glossary term" : "➕ glossary"}</button>
-        <Popup popUpRef={popupRef}>
+        <Popup popUpRef={popupRef} onClose={resetState}>
             <Container className={styles.cmPanelPopup}>
                 {isPhy && <>
                     <Label for={"glossary-subject-select"}>Select subject:</Label>
@@ -106,9 +113,6 @@ export const PopupGlossaryTermSelect = ({wide, codemirror}: { wide?: boolean, co
                 <PopupCloseContext.Consumer>
                     {close => <Button disabled={!glossaryTerm} onClick={() => {
                         generateAndInsertGlossaryTerm();
-                        setGlossaryTerm(undefined);
-                        setGlossaryTermText(undefined);
-                        setIsInlineTerm(true);
                         close?.();
                     }}>
                         Generate markup

--- a/src/components/popups/PopupInlineQuestionInsert.tsx
+++ b/src/components/popups/PopupInlineQuestionInsert.tsx
@@ -19,6 +19,13 @@ export const PopupInlineQuestionInsert = ({wide, codemirror}: { wide?: boolean, 
     const [classes, setClasses] = useState<string>();
     const [mode, setMode] = useState<"classes" | "dimensions">("classes");
 
+    const resetState = () => {
+        setWidth(undefined);
+        setHeight(undefined);
+        setClasses(undefined);
+        setID(undefined);
+    };
+
     const generateAndInsertInlinePart = useCallback(() => {
         const partId = id ? id : generateGuid().slice(0, 8);
         const inlinePartSyntax = mode === "classes" ? 
@@ -53,7 +60,7 @@ export const PopupInlineQuestionInsert = ({wide, codemirror}: { wide?: boolean, 
         <button className={styles.cmPanelButton} title={"Insert inline question part"} onClick={(event) => {
             popupRef.current?.open(event);
         }}>{wide ? "Add inline question part" : "➕ inline part"}</button>
-        <Popup popUpRef={popupRef}>
+        <Popup popUpRef={popupRef} onClose={resetState}>
             <Container className={styles.cmPanelPopup}>
                 <Label for={"inline-part-index"}>Part ID</Label>
                 <Input id={"inline-part-index"} placeholder={"Default"} onChange={ifContainsNoSpacesThen(setID)} />
@@ -84,10 +91,6 @@ export const PopupInlineQuestionInsert = ({wide, codemirror}: { wide?: boolean, 
                 <PopupCloseContext.Consumer>
                     {close => <Button disabled={!!invalid} onClick={() => {
                         generateAndInsertInlinePart();
-                        setWidth(undefined);
-                        setHeight(undefined);
-                        setClasses(undefined);
-                        setID(undefined);
                         close?.();
                     }}>Insert</Button>}
                 </PopupCloseContext.Consumer>

--- a/src/components/popups/PopupTableClass.tsx
+++ b/src/components/popups/PopupTableClass.tsx
@@ -70,7 +70,7 @@ export const PopupTableClass = ({wide, codemirror}: {wide: boolean, codemirror: 
                         if (e.target.checked) {
                             setClasses(prev => prev ? `${prev} topScrollable` : "topScrollable");
                         } else {
-                            setClasses(prev => prev?.replace(/\bscrollable\b/g, "").trim());
+                            setClasses(prev => prev?.replace(/\btopScrollable\b/g, "").trim());
                         }
                     }}/>
                 </InputGroup>

--- a/src/components/popups/PopupTableClass.tsx
+++ b/src/components/popups/PopupTableClass.tsx
@@ -13,6 +13,13 @@ export const PopupTableClass = ({wide, codemirror}: {wide: boolean, codemirror: 
     const [topScrollable, setTopScrollable] = useState<boolean>(false);
     const tableRegex = /<table(.*class=")(.*)(".*)>/i;
 
+    const resetState = () => {
+        const tableClasses = codemirror.current?.view?.state.doc.toString().match(tableRegex)?.[2];
+        setClasses(tableClasses ?? "");
+        setExpandable(tableClasses?.includes("expandable") ?? false);
+        setTopScrollable(tableClasses?.includes("topScrollable") ?? false);
+    };
+
     const makeTableClass = (className: string) => (view: EditorView | undefined) => {
         if (!view) return false;
         const docText = view.state.doc.toString();
@@ -40,12 +47,8 @@ export const PopupTableClass = ({wide, codemirror}: {wide: boolean, codemirror: 
     return <>
         <button className={styles.cmPanelButton} title={"Augment table"} onClick={(event) => {
             popupRef.current?.open(event);
-            const tableClasses = codemirror.current?.view?.state.doc.toString().match(tableRegex)?.[2];
-            setClasses(tableClasses ?? "");
-            setExpandable(tableClasses?.includes("expandable") ?? false);
-            setTopScrollable(tableClasses?.includes("topScrollable") ?? false);
         }}>{wide ? "Augment table" : "Table"}</button>
-        <Popup popUpRef={popupRef}>
+        <Popup popUpRef={popupRef} onClose={resetState}>
             <Container className={styles.cmPanelPopup}>
                 {isAda && <InputGroup className={"ps-4"}>
                     <Label for={"table-expandable"}>Expandable</Label>
@@ -76,9 +79,6 @@ export const PopupTableClass = ({wide, codemirror}: {wide: boolean, codemirror: 
                 <PopupCloseContext.Consumer>
                     {close => <Button disabled={!classes && !expandable && !topScrollable} onClick={() => {
                         makeTableClass(classes)(codemirror.current?.view);
-                        setExpandable(false);
-                        setTopScrollable(false);
-                        setClasses("");
                         close?.();
                     }}>
                         Add class

--- a/src/components/popups/PopupTableClass.tsx
+++ b/src/components/popups/PopupTableClass.tsx
@@ -47,6 +47,7 @@ export const PopupTableClass = ({wide, codemirror}: {wide: boolean, codemirror: 
     return <>
         <button className={styles.cmPanelButton} title={"Augment table"} onClick={(event) => {
             popupRef.current?.open(event);
+            resetState();
         }}>{wide ? "Augment table" : "Table"}</button>
         <Popup popUpRef={popupRef} onClose={resetState}>
             <Container className={styles.cmPanelPopup}>

--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -110,9 +110,9 @@ export function ItemQuestionPresenter(props: PresenterProps<ItemQuestionType>) {
         {(isClozeQuestion(doc) || isDndQuestion(doc)) && <div><CheckboxDocProp doc={doc} update={update} prop="detailedItemFeedback" label="Indicate which items are incorrect in question feedback" /></div>}
         <div><CheckboxDocProp doc={doc} update={update} prop="randomiseItems" label="Randomise items on question load" checkedIfUndefined={true} /></div>
         {isDndQuestion(doc) && <DndQuestionInstructions />}
-
-        <ContentValueOrChildrenPresenter {...props} update={updateWithDropZoneCount} topLevel />
         {isClozeQuestion(doc) && <ClozeQuestionInstructions />}
+        <ContentValueOrChildrenPresenter {...props} update={updateWithDropZoneCount} topLevel />
+
         <Box name="Items">
             <Row className={styles.itemsHeaderRow}>
                 <Col xs={3} className={styles.center}>


### PR DESCRIPTION
- Adds an "Add DnD drop-zone" button for `isaacDragAndDropQuestion`s
  - Includes a "Drop-zone ID" field which automatically increments A1, A2, A3, etc. based on the drop-zones already in the question (Note: if a drop-zone is deleted or editing the content is cancelled, the count will not update to reflect that until the content is successfully set. It's still safe from creating duplicates so I think this is fine)
  - Doesn't include the "Index override" field as this isn't needed for DnD questions
- Reworks validity checking to be more expansive
  - We previously checked that width/height/index were numbers and disabled the generate button if not, but there was no warning for what was wrong, no negative/integer value checking, and the validity would be overwritten when editing another field. This has all been implemented/fixed