### PR TITLE
Separate question-specific ItemQuestion code (+ add useSingleList reorder option)

### DIFF
--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -59,6 +59,10 @@ function isParsonsQuestion(doc: Content | null | undefined): doc is IsaacParsons
     return doc?.type === "isaacParsonsQuestion";
 }
 
+function isReorderQuestion(doc: Content | null | undefined): doc is IsaacReorderQuestion {
+    return doc?.type === "isaacReorderQuestion";
+}
+
 function isClozeQuestion(doc: Content | null | undefined): doc is IsaacClozeQuestion {
     return doc?.type === "isaacClozeQuestion";
 }
@@ -106,6 +110,7 @@ export function ItemQuestionPresenter(props: PresenterProps<ItemQuestionType>) {
         calculateDZIndexFromFigureId: (id) => extractFigureRegionStartIndex(doc, id),
     }}>
         {isParsonsQuestion(doc) && <div><CheckboxDocProp doc={doc} update={update} prop="disableIndentation" label="Disable indentation" /></div>}
+        {(isParsonsQuestion(doc) || isReorderQuestion(doc)) && <div><CheckboxDocProp doc={doc} update={update} prop="useSingleList" label="Display only one list (all items must be required)" /></div>}
         {(isClozeQuestion(doc) || isDndQuestion(doc)) && <div><CheckboxDocProp doc={doc} update={update} prop="withReplacement" label="Allow items to be used more than once" /></div>}
         {(isClozeQuestion(doc) || isDndQuestion(doc)) && <div><CheckboxDocProp doc={doc} update={update} prop="detailedItemFeedback" label="Indicate which items are incorrect in question feedback" /></div>}
         <div><CheckboxDocProp doc={doc} update={update} prop="randomiseItems" label="Randomise items on question load" checkedIfUndefined={true} /></div>

--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -59,10 +59,6 @@ function isParsonsQuestion(doc: Content | null | undefined): doc is IsaacParsons
     return doc?.type === "isaacParsonsQuestion";
 }
 
-function isReorderQuestion(doc: Content | null | undefined): doc is IsaacReorderQuestion {
-    return doc?.type === "isaacReorderQuestion";
-}
-
 function isClozeQuestion(doc: Content | null | undefined): doc is IsaacClozeQuestion {
     return doc?.type === "isaacClozeQuestion";
 }
@@ -73,7 +69,7 @@ function isDndQuestion(doc: Content | null | undefined): doc is IsaacDndQuestion
 
 type ItemQuestionType = IsaacItemQuestion | IsaacReorderQuestion | IsaacParsonsQuestion | IsaacClozeQuestion | IsaacDndQuestion;
 
-export function ItemQuestionPresenter(props: PresenterProps<ItemQuestionType>) {
+export function ClozeDndQuestionPresenter(props: PresenterProps<IsaacClozeQuestion | IsaacDndQuestion>) {
     const {doc, update} = props;
 
     // Logic to count cloze question drop zones (if necessary) on initial presenter render and doc update
@@ -109,14 +105,31 @@ export function ItemQuestionPresenter(props: PresenterProps<ItemQuestionType>) {
         figureMap: figureMap.current,
         calculateDZIndexFromFigureId: (id) => extractFigureRegionStartIndex(doc, id),
     }}>
-        {isParsonsQuestion(doc) && <div><CheckboxDocProp doc={doc} update={update} prop="disableIndentation" label="Disable indentation" /></div>}
-        {(isParsonsQuestion(doc) || isReorderQuestion(doc)) && <div><CheckboxDocProp doc={doc} update={update} prop="useSingleList" label="Display only one list (all items must be required)" /></div>}
-        {(isClozeQuestion(doc) || isDndQuestion(doc)) && <div><CheckboxDocProp doc={doc} update={update} prop="withReplacement" label="Allow items to be used more than once" /></div>}
-        {(isClozeQuestion(doc) || isDndQuestion(doc)) && <div><CheckboxDocProp doc={doc} update={update} prop="detailedItemFeedback" label="Indicate which items are incorrect in question feedback" /></div>}
+        <div><CheckboxDocProp doc={doc} update={update} prop="withReplacement" label="Allow items to be used more than once" /></div>
+        <div><CheckboxDocProp doc={doc} update={update} prop="detailedItemFeedback" label="Indicate which items are incorrect in question feedback" /></div>
         <div><CheckboxDocProp doc={doc} update={update} prop="randomiseItems" label="Randomise items on question load" checkedIfUndefined={true} /></div>
         {isDndQuestion(doc) && <DndQuestionInstructions />}
         {isClozeQuestion(doc) && <ClozeQuestionInstructions />}
-        <ContentValueOrChildrenPresenter {...props} update={updateWithDropZoneCount} topLevel />
+        <ItemQuestionPresenter {...props} update={updateWithDropZoneCount}/>
+    </DropZoneQuestionContext.Provider>;
+}
+
+export function ReorderParsonsQuestionPresenter(props: PresenterProps<IsaacReorderQuestion | IsaacParsonsQuestion>) {
+    const {doc, update} = props;
+
+    return <>
+        {isParsonsQuestion(doc) && <div><CheckboxDocProp doc={doc} update={update} prop="disableIndentation" label="Disable indentation" /></div>}
+        <div><CheckboxDocProp doc={doc} update={update} prop="useSingleList" label="Reorder within single list (all items are required in all answers)" /></div>
+        <ItemQuestionPresenter {...props} />
+    </>;
+}
+
+export function ItemQuestionPresenter(props: PresenterProps<ItemQuestionType>) {
+    const {doc, update} = props;
+
+    return <>
+        {!isClozeQuestion(doc) && !isDndQuestion(doc) && <div><CheckboxDocProp doc={doc} update={update} prop="randomiseItems" label="Randomise items on question load" checkedIfUndefined={true} /></div>}
+        <ContentValueOrChildrenPresenter {...props} topLevel />
 
         <Box name="Items">
             <Row className={styles.itemsHeaderRow}>
@@ -139,7 +152,7 @@ export function ItemQuestionPresenter(props: PresenterProps<ItemQuestionType>) {
         }}>
             <QuestionFooterPresenter {...props} />
         </ItemsContext.Provider>
-    </DropZoneQuestionContext.Provider>;
+    </>;
 }
 
 export function ItemPresenter(props: PresenterProps<Item>) {

--- a/src/components/semantic/presenters/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/ItemQuestionPresenter.tsx
@@ -105,9 +105,9 @@ export function ClozeDndQuestionPresenter(props: PresenterProps<IsaacClozeQuesti
         figureMap: figureMap.current,
         calculateDZIndexFromFigureId: (id) => extractFigureRegionStartIndex(doc, id),
     }}>
-        <div><CheckboxDocProp doc={doc} update={update} prop="withReplacement" label="Allow items to be used more than once" /></div>
-        <div><CheckboxDocProp doc={doc} update={update} prop="detailedItemFeedback" label="Indicate which items are incorrect in question feedback" /></div>
-        <div><CheckboxDocProp doc={doc} update={update} prop="randomiseItems" label="Randomise items on question load" checkedIfUndefined={true} /></div>
+        <CheckboxDocProp doc={doc} update={update} prop="withReplacement" label="Allow items to be used more than once" />
+        <CheckboxDocProp doc={doc} update={update} prop="detailedItemFeedback" label="Indicate which items are incorrect in question feedback" />
+        <CheckboxDocProp doc={doc} update={update} prop="randomiseItems" label="Randomise items on question load" checkedIfUndefined={true} />
         {isDndQuestion(doc) && <DndQuestionInstructions />}
         {isClozeQuestion(doc) && <ClozeQuestionInstructions />}
         <ItemQuestionPresenter {...props} update={updateWithDropZoneCount}/>
@@ -118,8 +118,8 @@ export function ReorderParsonsQuestionPresenter(props: PresenterProps<IsaacReord
     const {doc, update} = props;
 
     return <>
-        {isParsonsQuestion(doc) && <div><CheckboxDocProp doc={doc} update={update} prop="disableIndentation" label="Disable indentation" /></div>}
-        <div><CheckboxDocProp doc={doc} update={update} prop="useSingleList" label="Reorder within single list (all items are required in all answers)" /></div>
+        {isParsonsQuestion(doc) && <CheckboxDocProp doc={doc} update={update} prop="disableIndentation" label="Disable indentation" />}
+        <CheckboxDocProp doc={doc} update={update} prop="useSingleList" label="Reorder within single list (all items are required in all answers)" />
         <ItemQuestionPresenter {...props} />
     </>;
 }
@@ -128,7 +128,8 @@ export function ItemQuestionPresenter(props: PresenterProps<ItemQuestionType>) {
     const {doc, update} = props;
 
     return <>
-        {!isClozeQuestion(doc) && !isDndQuestion(doc) && <div><CheckboxDocProp doc={doc} update={update} prop="randomiseItems" label="Randomise items on question load" checkedIfUndefined={true} /></div>}
+        {/* Defined above question instructions instead for cloze and dnd questions */}
+        {!isClozeQuestion(doc) && !isDndQuestion(doc) && <CheckboxDocProp doc={doc} update={update} prop="randomiseItems" label="Randomise items on question load" checkedIfUndefined={true} />}
         <ContentValueOrChildrenPresenter {...props} topLevel />
 
         <Box name="Items">

--- a/src/components/semantic/registry.tsx
+++ b/src/components/semantic/registry.tsx
@@ -37,10 +37,12 @@ import {defaultMeta, MetaItemKey} from "./Metadata";
 import {CardDeckPresenter, CardPresenter} from "./presenters/CardPresenter";
 import {MetaItems} from "./metaItems";
 import {
+    ClozeDndQuestionPresenter,
     DndChoicePresenter,
     ItemChoicePresenter,
     ItemPresenter,
-    ItemQuestionPresenter
+    ItemQuestionPresenter,
+    ReorderParsonsQuestionPresenter
 } from "./presenters/ItemQuestionPresenter";
 import styles from "./styles/semantic.module.css";
 import {ListChildrenPresenter} from "./presenters/ListChildrenPresenter";
@@ -178,6 +180,16 @@ const isaacStringMatchQuestion = {
 const isaacItemQuestion = {
     ...question,
     bodyPresenter: ItemQuestionPresenter,
+    footerPresenter: undefined,
+};
+const isaacClozeDragAndDropQuestion = {
+    ...question,
+    bodyPresenter: ClozeDndQuestionPresenter,
+    footerPresenter: undefined,
+};
+const isaacReorderParsonsQuestion = {
+    ...question,
+    bodyPresenter: ReorderParsonsQuestionPresenter,
     footerPresenter: undefined,
 };
 const isaacLLMFreeTextQuestion: RegistryEntry = {
@@ -403,12 +415,12 @@ export const REGISTRY: Record<ContentType, RegistryEntry> = {
     isaacGraphSketcherQuestion: {...question, headerPresenter: GraphSketcherQuestionPresenter},
     graphChoice: choice,
     isaacItemQuestion,
-    isaacReorderQuestion: isaacItemQuestion,
-    isaacParsonsQuestion: isaacItemQuestion,
+    isaacReorderQuestion: isaacReorderParsonsQuestion,
+    isaacParsonsQuestion: isaacReorderParsonsQuestion,
     itemChoice: choice,
     parsonsChoice: choice,
-    isaacClozeQuestion: isaacItemQuestion,
-    isaacDndQuestion: isaacItemQuestion,
+    isaacClozeQuestion: isaacClozeDragAndDropQuestion,
+    isaacDndQuestion: isaacClozeDragAndDropQuestion,
     dndChoice: choice,
     dndItem$choice: {bodyPresenter: DndChoicePresenter},
     coordinateItem$choice: {bodyPresenter: CoordinateItemPresenter},

--- a/src/components/semantic/styles/question.module.css
+++ b/src/components/semantic/styles/question.module.css
@@ -6,6 +6,7 @@
 .checkboxLabel {
     margin-left: 1.25rem;
     margin-right: 0.5rem;
+    display: flex;
 }
 
 .questionLabel {

--- a/src/isaac-data-types.d.ts
+++ b/src/isaac-data-types.d.ts
@@ -174,9 +174,12 @@ export interface IsaacPageFragment extends Content {
 
 export interface IsaacParsonsQuestion extends IsaacItemQuestion {
     disableIndentation?: boolean;
+    useSingleList?: boolean;
 }
 
-export type IsaacReorderQuestion = IsaacItemQuestion
+export interface IsaacReorderQuestion extends IsaacItemQuestion {
+    useSingleList?: boolean;
+}
 
 export interface IsaacPod extends Content {
     image?: Image;


### PR DESCRIPTION
The same component was being used for `Item`/`Reorder`/`Parsons`/`Cloze`/`DragAndDrop` questions because they share some base `Item` functionality, but `Reorder`/`Parsons` questions share some logic not used by the other types, and `Cloze`/`DragAndDrop` share a lot of logic not used by the other types.

To make the overall code more readable, the base `IsaacItemQuestion` now has its own `Presenter`, and reorder/parsons and cloze/dnd questions have their own `Presenter`s that use it as a child (using a child rather than using the header + body + footer format because cloze/dnd needs it to propagate its altered `updateWithDropZoneCount` function)

\+ Add `useSingleList` prop and checkbox to correspond with change to allow new reorder-in-place style reorder/parsons questions