### PR TITLE
Use second endpoint rq to obtain fasttrack questions

### DIFF
--- a/src/components/semantic/presenters/ArrayPropPresenter.tsx
+++ b/src/components/semantic/presenters/ArrayPropPresenter.tsx
@@ -9,6 +9,8 @@ function readableContentType(type: string | undefined) {
     switch (type) {
         case "isaacQuestionPage":
             return "Question";
+        case "isaacFastTrackQuestionPage":
+            return "FastTrack Q";
         case "isaacConceptPage":
             return "Concept";
         case "isaacTopicSummaryPage":

--- a/src/components/semantic/presenters/RelatedContentPresenter.tsx
+++ b/src/components/semantic/presenters/RelatedContentPresenter.tsx
@@ -8,16 +8,26 @@ import { ArrayPropValueConstraintContext, ArrayPropPresenterInner } from "./Arra
 export function RelatedContentPresenter({doc, update}: PresenterProps) {
     const [searchString, setSearchString] = useState("");
 
-    const {data: relatedContent} = useSWR<{results: Content[]}>(
+    // TODO the site search endpoint currently doesn't include fasttrack questions, so we're using a separate endpoint call to ensure we can get those.
+    // TODO if/when site search allows fasttracks, merge these two calls together.
+
+    const {data: relatedNonFastTrack} = useSWR<{results: Content[]}>(
         searchString !== "" ? "search?query=" + encodeURIComponent(searchString) + "&types=isaacConceptPage,isaacQuestionPage" : null,
         stagingFetcher,
     );
 
-    return <ArrayPropValueConstraintContext.Provider value={{searchString, setSearchString, content: relatedContent?.results ?? [], mapContentToId: (c: Content) => c.id ?? ""}}>
+    const {data: relatedFastTrack} = useSWR<{results: Content[]}>(
+        searchString !== "" ? "pages/questions?searchString=" + encodeURIComponent(searchString) + "&fasttrack=true" : null,
+        stagingFetcher,
+    );
+
+    const relatedContent = [...(relatedNonFastTrack?.results ?? []), ...(relatedFastTrack?.results ?? [])];
+
+    return <ArrayPropValueConstraintContext.Provider value={{searchString, setSearchString, content: relatedContent ?? [], mapContentToId: (c: Content) => c.id ?? ""}}>
         <ArrayPropPresenterInner 
             doc={doc} update={update} prop="relatedContent" getChildId={(c: string) => c ?? ""} 
             calculateButtonProps={(c: Content) => ({
-                color: c.type === "isaacQuestionPage" ? "success" : "primary",
+                color: c.type === "isaacQuestionPage" ? "success" : c.type === "isaacFastTrackQuestionPage" ? "secondary" : "primary",
             })}
         />
     </ArrayPropValueConstraintContext.Provider>;


### PR DESCRIPTION
Uses a second endpoint request to obtain fasttrack options for the Related Content field in the editor.

This isn't the cleanest way of doing this, but it doesn't need to be; content were happy with a quick and dirty solution to this while they further discuss whether site search should show FT questions and how they may need to e.g. modify their titles to show correctly.