### PR TITLE
Extend input validation for parsons indentation

### DIFF
--- a/src/components/semantic/Metadata.tsx
+++ b/src/components/semantic/Metadata.tsx
@@ -10,14 +10,17 @@ import { AppContext } from "../../App";
 
 import styles from "./styles/metadata.module.css";
 
-export interface MetaOptions {
+export type MetaOptions = {
     hasWarning?: (value: unknown, context: ContextType<typeof AppContext>) => string | undefined;
-    type?: InputType;
     presenter?: React.FunctionComponent<MetaItemPresenterProps>;
     defaultValue?: unknown;
     deleteIfEmpty?: boolean;
     options?: Record<string, string>;
-}
+} & (
+    { type?: Exclude<InputType, "number">; min?: never; max?: never;} |
+    { type: "number"; min?: number; max?: number; }
+);
+
 type MetaItem = string | [string, MetaOptions];
 
 // This identity helper function exists to generate the type T, which is record scoped to our
@@ -96,6 +99,8 @@ export function MetaItemPresenter({doc, update, id, prop, name, options}: MetaIt
             )}
             placeholder={name}
             id={id}
+            min={options?.type === "number" ? options.min : undefined}
+            max={options?.type === "number" ? options.max : undefined}
         />
         {warning && <FormText>{warning}</FormText>}
     </>;

--- a/src/components/semantic/presenters/ChoicePresenter.tsx
+++ b/src/components/semantic/presenters/ChoicePresenter.tsx
@@ -216,7 +216,7 @@ export const GraphChoicePresenter = buildValuePresenter(
 );
 
 export const ItemChoicePresenter = (props: ValuePresenterProps<ItemChoice>) => {
-    const {items: maybeItems, withReplacement, requireAllItems} = useContext(ItemsContext);
+    const {items: maybeItems, withReplacement, requireAllItems, disableIndentation} = useContext(ItemsContext);
     const {isClozeQuestion, dropZoneCount} = useContext(DropZoneQuestionContext);
     const {doc, update} = props;
 
@@ -270,7 +270,7 @@ export const ItemChoicePresenter = (props: ValuePresenterProps<ItemChoice>) => {
         {doc.type === "parsonsChoice" && requireAllItems && remainingItems.length !== 0 && <Alert color="warning">
             All items are required when reordering within one list.
         </Alert>}
-        <ItemsContext.Provider value={{items, remainingItems, remainingDropZones: undefined, withReplacement, allowSubsetMatch: doc.allowSubsetMatch, isCorrect: doc.correct}}>
+        <ItemsContext.Provider value={{items, remainingItems, remainingDropZones: undefined, withReplacement, disableIndentation, allowSubsetMatch: doc.allowSubsetMatch, isCorrect: doc.correct}}>
             <ListPresenterProp {...props} doc={doc} update={augmentedUpdate} prop="items" childTypeOverride="item$choice" />
         </ItemsContext.Provider>
     </>;
@@ -278,7 +278,7 @@ export const ItemChoicePresenter = (props: ValuePresenterProps<ItemChoice>) => {
 
 export const DndChoicePresenter = (props: ValuePresenterProps<DndChoice>) => {
     const {doc, update} = props;
-    const {items: maybeItems, withReplacement} = useContext(ItemsContext);
+    const {items: maybeItems, withReplacement, disableIndentation} = useContext(ItemsContext);
     const {dropZoneIds: maybeDropZoneIds} = useContext(DropZoneQuestionContext);
 
     const items = maybeItems ?? [];
@@ -289,7 +289,7 @@ export const DndChoicePresenter = (props: ValuePresenterProps<DndChoice>) => {
 
     return <>
         <span>Add an entry here to attach one Item to one Drop Zone.</span>
-        <ItemsContext.Provider value={{items, remainingItems, remainingDropZones, withReplacement, allowSubsetMatch: undefined, isCorrect: doc.correct}}>
+        <ItemsContext.Provider value={{items, remainingItems, remainingDropZones, withReplacement, disableIndentation, allowSubsetMatch: undefined, isCorrect: doc.correct}}>
             <ListPresenterProp {...props} doc={doc} update={update} prop="items" childTypeOverride="dndItem$choice" />
         </ItemsContext.Provider>
         {dropZoneIds.length === 0 && <Alert color={"warning"} className="mt-3">

--- a/src/components/semantic/presenters/questions/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/questions/ItemQuestionPresenter.tsx
@@ -21,14 +21,13 @@ import {PresenterProps} from "../../registry";
 import {CheckboxDocProp} from "../../props/CheckboxDocProp";
 import {ListPresenterProp} from "../../props/listProps";
 import {ContentValueOrChildrenPresenter} from "../ContentValueOrChildrenPresenter";
-import {MetaItemPresenter, MetaOptions} from "../../Metadata";
+import {MetaItemPresenter} from "../../Metadata";
 
 import styles from "../../styles/question.module.css";
 import {Box} from "../../SemanticItem";
 import {ExpandableText} from "../../ExpandableText";
 import {extractDropZoneIdsPerFigure, extractFigureRegionStartIndex, extractValueOrChildrenText} from "../../../../utils/content";
 import {DND_ITEM_TYPE, dndDropZoneRegex, dropZoneRegex, NULL_CLOZE_ITEM, NULL_CLOZE_ITEM_ID} from "../../../../isaac/IsaacTypes";
-import classNames from "classnames";
 
 interface ItemsContextType {
     items?: Item[];
@@ -237,7 +236,9 @@ export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
                 style={{borderLeftWidth: `calc(1px + ${Math.min(3, doc.indentation ?? 0) * 1.5}em)`}}>
                 {dropdown}
                 <span className={styles.parsonsIndentPresenter}>
-                    <MetaItemPresenter {...props} prop="indentation" name="Indent" options={{type: "number"}} />
+                    <MetaItemPresenter {...props} prop="indentation" name="Indent" options={
+                        { type: "number", min: 0, max: disableIndentation ? 0 : 3}
+                    } />
                 </span>
             </div>
             {disableIndentation && doc.indentation !== 0 && <Alert color="warning" className="mt-3">

--- a/src/components/semantic/presenters/questions/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/questions/ItemQuestionPresenter.tsx
@@ -28,6 +28,7 @@ import {Box} from "../../SemanticItem";
 import {ExpandableText} from "../../ExpandableText";
 import {extractDropZoneIdsPerFigure, extractFigureRegionStartIndex, extractValueOrChildrenText} from "../../../../utils/content";
 import {DND_ITEM_TYPE, dndDropZoneRegex, dropZoneRegex, NULL_CLOZE_ITEM, NULL_CLOZE_ITEM_ID} from "../../../../isaac/IsaacTypes";
+import classNames from "classnames";
 
 interface ItemsContextType {
     items?: Item[];
@@ -37,10 +38,11 @@ interface ItemsContextType {
     allowSubsetMatch?: boolean;
     isCorrect?: boolean;
     requireAllItems?: boolean;
+    disableIndentation?: boolean;
 }
 
 export const ItemsContext = createContext<ItemsContextType>(
-    {items: undefined, remainingItems: undefined, remainingDropZones: undefined, withReplacement: undefined, allowSubsetMatch: undefined, isCorrect: undefined, requireAllItems: undefined}
+    {items: undefined, remainingItems: undefined, remainingDropZones: undefined, withReplacement: undefined, allowSubsetMatch: undefined, isCorrect: undefined, requireAllItems: undefined, disableIndentation: undefined}
 );
 export const DropZoneQuestionContext = createContext<{
     isDndQuestion: boolean,
@@ -155,7 +157,8 @@ export function ItemQuestionPresenter(props: PresenterProps<ItemQuestionType>) {
             withReplacement: (isClozeQuestion(doc) || isDndQuestion(doc)) && doc.withReplacement,
             allowSubsetMatch: undefined,
             isCorrect: undefined,
-            requireAllItems: (isReorderQuestion(doc) || isParsonsQuestion(doc)) && doc.useSingleList
+            requireAllItems: (isReorderQuestion(doc) || isParsonsQuestion(doc)) && doc.useSingleList,
+            disableIndentation: isParsonsQuestion(doc) && doc.disableIndentation,
         }}>
             <QuestionFooterPresenter {...props} />
         </ItemsContext.Provider>
@@ -205,7 +208,7 @@ const indentationOptions: MetaOptions = {type: "number", hasWarning: (value) => 
 export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
     const {doc, update} = props;
     const [isOpen, setOpen] = useState(false);
-    const {items, remainingItems, allowSubsetMatch} = useContext(ItemsContext);
+    const {items, remainingItems, allowSubsetMatch, disableIndentation} = useContext(ItemsContext);
     const {isClozeQuestion} = useContext(DropZoneQuestionContext);
 
     const item = items?.find((item) => item.id === doc.id) ?? {

--- a/src/components/semantic/presenters/questions/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/questions/ItemQuestionPresenter.tsx
@@ -197,14 +197,6 @@ function ItemRow({item}: {item: Item}) {
         </Row>;
 }
 
-// Resuse the MetaItemPresenter as it gives a live editable view
-const indentationOptions: MetaOptions = {type: "number", hasWarning: (value) => {
-    const num = value as number;
-    if (isNaN(num) || num < 0 || num > 3) {
-        return "Outside 0–3";
-    }
-}};
-
 export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
     const {doc, update} = props;
     const [isOpen, setOpen] = useState(false);
@@ -240,13 +232,20 @@ export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
     </Dropdown>;
 
     if (doc.type === "parsonsItem") {
-        return <div className={styles.parsonsItem}
-            style={{borderLeftWidth: `calc(1px + ${Math.min(3, doc.indentation ?? 0) * 1.5}em)`}}>
-            {dropdown}
-            <span className={styles.parsonsIndentPresenter}>
-                <MetaItemPresenter {...props} prop="indentation" name="Indent"
-                    options={indentationOptions} />
-            </span>
+        return <div>
+            <div className={styles.parsonsItem}
+                style={{borderLeftWidth: `calc(1px + ${Math.min(3, doc.indentation ?? 0) * 1.5}em)`}}>
+                {dropdown}
+                <span className={styles.parsonsIndentPresenter}>
+                    <MetaItemPresenter {...props} prop="indentation" name="Indent" options={{type: "number"}} />
+                </span>
+            </div>
+            {disableIndentation && doc.indentation !== 0 && <Alert color="warning" className="mt-3">
+                Indentation is disabled for this question.
+            </Alert>}
+            {!!doc.indentation && (doc.indentation < 0 || doc.indentation > 3) && <Alert color="warning" className="mt-3">
+                Indentation must be between 0 and 3.
+            </Alert>}
         </div>;
     } else {
         return <div className={styles.itemsChoiceRow}>

--- a/src/components/semantic/presenters/questions/ItemQuestionPresenter.tsx
+++ b/src/components/semantic/presenters/questions/ItemQuestionPresenter.tsx
@@ -241,7 +241,7 @@ export function ItemChoicePresenter(props: PresenterProps<ParsonsItem>) {
 
     if (doc.type === "parsonsItem") {
         return <div className={styles.parsonsItem}
-            style={{borderLeftWidth: `calc(1px + ${(doc.indentation ?? 0) * 1.5}em)`}}>
+            style={{borderLeftWidth: `calc(1px + ${Math.min(3, doc.indentation ?? 0) * 1.5}em)`}}>
             {dropdown}
             <span className={styles.parsonsIndentPresenter}>
                 <MetaItemPresenter {...props} prop="indentation" name="Indent"

--- a/src/components/semantic/styles/question.module.css
+++ b/src/components/semantic/styles/question.module.css
@@ -126,5 +126,5 @@
 }
 
 .parsonsIndentPresenter {
-    min-width: 50px;
+    min-width: 60px;
 }


### PR DESCRIPTION
Add `<Alert>`s for invalid indentations, rather than using `hasWarning` which only shows up once editing the field - so that possible errors can be found for old pages. This includes the existing warning to keep indentation between 0 and 3, and a new warning to not use indentation at all for `disableIndentation` questions.

Also adds `min` and `max` for "number"-based `metaItems`, and use them to cap button-based inputs between 0 and 3 for indentation, and stop css from indenting an item past 3 even if they do reach that value.